### PR TITLE
fix(duo-regna): lobby ao fim da partida e nova partida

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -191,8 +191,9 @@
     --color-warning: #fcd34d;
     --color-on-warning: var(--color-golden-deep);
 
-    --color-tile-surface: #c4956a;
-    --color-tile-step: #1f0a0c;
+    /* Hexágonos da base dos botões da home (skin 03) */
+    --color-tile-surface: #4b4a52;
+    --color-tile-step: #1d1828;
   }
 
   [data-theme='dark'] {

--- a/app/components/board/tile.component.tsx
+++ b/app/components/board/tile.component.tsx
@@ -67,7 +67,7 @@ export const FlamingoTile = (
 export const PegasusTile = (
   props: Omit<ButtonTileProps, 'children' | 'data-theme'>,
 ) => (
-  <ButtonTile {...props} data-theme="pegasus">
+  <ButtonTile {...props}>
     {(show) => (
       <div className="relative -top-1 -left-21">
         <Pegasus show={show} />

--- a/app/components/duo-regna-play/duo-regna-play.component.tsx
+++ b/app/components/duo-regna-play/duo-regna-play.component.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useRevalidator } from 'react-router'
+import { useNavigate, useRevalidator } from 'react-router'
 import Button from '~/components/button/button.component'
 import type { DuoRegnaCardValue, DuoRegnaClientState } from '~/lib/duo-regna'
 import { useSocket } from '~/services/socket-context'
@@ -33,10 +33,16 @@ export default function DuoRegnaPlay({
   finishedFromLoader: boolean
 }) {
   const socket = useSocket()
+  const navigate = useNavigate()
   const revalidator = useRevalidator()
   const [state, setState] = useState<DuoRegnaClientState | null>(initialClientState)
   const [error, setError] = useState<string | null>(null)
   const finished = finishedFromLoader || state?.status === 'finished'
+
+  useEffect(() => {
+    if (!finished) return
+    void navigate(`/games/duo-regna/rooms/${roomCode}`)
+  }, [finished, navigate, roomCode])
 
   useEffect(() => {
     if (!socket) return
@@ -61,7 +67,7 @@ export default function DuoRegnaPlay({
       socket.off('duo_regna_finished', onFin)
       socket.emit('leave_room', roomCode)
     }
-  }, [socket, roomCode, revalidator])
+  }, [socket, roomCode, navigate, revalidator])
 
   useEffect(() => {
     if (initialClientState) setState(initialClientState)

--- a/app/routes/games_.duo-regna.rooms_.$roomCode/route.tsx
+++ b/app/routes/games_.duo-regna.rooms_.$roomCode/route.tsx
@@ -29,10 +29,7 @@ export const loader = async ({ context, params }: Route.LoaderArgs) => {
     return redirect('/games/duo-regna/rooms/index')
   }
 
-  if (
-    room.status === DuoRegnaRoomStatus.PLAYING ||
-    room.status === DuoRegnaRoomStatus.FINISHED
-  ) {
+  if (room.status === DuoRegnaRoomStatus.PLAYING) {
     return redirect(`/games/duo-regna/rooms/${params.roomCode}/play`)
   }
 
@@ -59,10 +56,15 @@ export default function Route({ loaderData, actionData, params }: Route.Componen
     socket.on('room_joined', onJoin)
     socket.on('room_left', onLeft)
     socket.on('duo_regna_game_started', onStart)
+    const onLobbyUpdated = async () => {
+      await revalidator.revalidate()
+    }
+    socket.on('duo_regna_lobby_updated', onLobbyUpdated)
     return () => {
       socket.off('room_joined', onJoin)
       socket.off('room_left', onLeft)
       socket.off('duo_regna_game_started', onStart)
+      socket.off('duo_regna_lobby_updated', onLobbyUpdated)
       socket.emit('leave_room', loaderData.room.roomCode)
     }
   }, [socket, loaderData.room.roomCode, navigate, params.roomCode, revalidator])
@@ -110,6 +112,20 @@ export default function Route({ loaderData, actionData, params }: Route.Componen
           },
         ]}
       />
+      {loaderData.room.status === DuoRegnaRoomStatus.FINISHED && (
+        <>
+          <Spacer size="md" />
+          <p className="text-center text-sm text-foreground/70">
+            A partida terminou. Prepara a mesa para jogar outra vez.
+          </p>
+          <Spacer size="sm" />
+          <Form className="flex justify-center" method="post">
+            <input type="hidden" name="intent" value="reset_after_game" />
+            <input type="hidden" name="roomId" value={loaderData.room.id} />
+            <Button type="submit">Nova partida</Button>
+          </Form>
+        </>
+      )}
       {loaderData.room.players.length === 2 && loaderData.room.status === DuoRegnaRoomStatus.WAITING && (
         <>
           <Spacer size="md" />
@@ -147,6 +163,34 @@ export const action = async ({ context, request, params }: Route.ActionArgs) => 
     }
     context.io.emit('room_left')
     return redirect('/games/duo-regna/rooms/index')
+  }
+
+  if (intent === 'reset_after_game') {
+    const roomId = Number(formData.get('roomId'))
+    const room = await context.prisma.duoRegnaRoom.findFirst({
+      where: {
+        id: roomId,
+        roomCode: String(params.roomCode),
+        status: DuoRegnaRoomStatus.FINISHED,
+        players: { some: { userId: context.currentUser.id } },
+      },
+    })
+    if (!room) {
+      return data({ error: 'Sala não encontrada ou ainda em jogo.' })
+    }
+    await context.prisma.duoRegnaRoomPlayer.updateMany({
+      where: { roomId: room.id },
+      data: { winner: false },
+    })
+    await context.prisma.duoRegnaRoom.update({
+      where: { id: room.id },
+      data: {
+        status: DuoRegnaRoomStatus.WAITING,
+        gameState: {},
+      },
+    })
+    context.io.to(params.roomCode).emit('duo_regna_lobby_updated')
+    return redirect(`/games/duo-regna/rooms/${params.roomCode}`)
   }
 
   if (intent === 'start') {

--- a/app/routes/games_.duo-regna.rooms_.$roomCode_.play/route.tsx
+++ b/app/routes/games_.duo-regna.rooms_.$roomCode_.play/route.tsx
@@ -22,6 +22,10 @@ export const loader = async ({ context, params }: Route.LoaderArgs) => {
     return redirect('/games/duo-regna/rooms/index')
   }
 
+  if (room.status === DuoRegnaRoomStatus.FINISHED) {
+    return redirect(`/games/duo-regna/rooms/${params.roomCode}`)
+  }
+
   if (room.status === DuoRegnaRoomStatus.WAITING) {
     return redirect(`/games/duo-regna/rooms/${params.roomCode}`)
   }
@@ -34,13 +38,12 @@ export const loader = async ({ context, params }: Route.LoaderArgs) => {
   const player = room.players.find((a) => a.userId === currentUser.id)!
   const seat = player.seat as 0 | 1
   const initialClientState = toClientState(gs, seat, room.status)
-  const finishedFromLoader = room.status === DuoRegnaRoomStatus.FINISHED
 
   return {
     roomCode: room.roomCode,
     seat,
     initialClientState,
-    finishedFromLoader,
+    finishedFromLoader: false,
   }
 }
 

--- a/app/routes/games_.duo-regna.rooms_.index/route.tsx
+++ b/app/routes/games_.duo-regna.rooms_.index/route.tsx
@@ -82,7 +82,9 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
   })
 
   if (playingRooms) {
-    const inLobby = playingRooms.status === DuoRegnaRoomStatus.WAITING
+    const inLobby =
+      playingRooms.status === DuoRegnaRoomStatus.WAITING ||
+      playingRooms.status === DuoRegnaRoomStatus.FINISHED
     return redirect(
       `/games/duo-regna/rooms/${playingRooms.roomCode}${inLobby ? '' : '/play'}`,
     )


### PR DESCRIPTION
- Redireciona /play para lobby quando FINISHED; play navega ao estado finished

- Lobby: reset_after_game (WAITING, limpa winner), evento duo_regna_lobby_updated

- Index: FINISHED abre lobby, não /play

- Skin golden: hexágonos #4B4A52 / #1D1828; PegasusTile sem data-theme no tile

Made-with: Cursor