### PR TITLE
feat(enigmas): card symbols, admin list UX, fix entrada loader leak

### DIFF
--- a/app/components/enigma-card-symbol/enigma-card-symbol-form-field.component.tsx
+++ b/app/components/enigma-card-symbol/enigma-card-symbol-form-field.component.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+
+import type { EnigmaCardSymbol } from '~/generated/prisma/enums'
+
+import {
+  ENIGMA_CARD_SYMBOL_OPTIONS,
+  EnigmaCardSymbolIcon,
+} from './enigma-card-symbol.component'
+
+export function EnigmaCardSymbolFormField({
+  defaultSymbol,
+  helperText,
+}: {
+  defaultSymbol: EnigmaCardSymbol
+  helperText: ReactNode
+}) {
+  return (
+    <fieldset
+      id="enigma-card-symbol-fieldset"
+      className="rounded-xl border-2 border-foreground/20 bg-foreground/[0.02] p-4 shadow-sm"
+    >
+      <legend className="px-1 font-brand text-sm font-semibold uppercase tracking-[0.12em] text-foreground/70 sm:text-base">
+        Símbolo do cartão
+      </legend>
+      <p className="mb-4 mt-2 text-sm text-foreground/55">{helperText}</p>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-5">
+        {ENIGMA_CARD_SYMBOL_OPTIONS.map((opt) => (
+          <label
+            key={opt.value}
+            className="flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-foreground/20 bg-background px-2 py-3 text-center transition-colors hover:border-foreground/30 has-[:checked]:border-primary has-[:checked]:bg-primary/5 has-[:focus-within]:ring-2 has-[:focus-within]:ring-primary/40"
+          >
+            <input
+              type="radio"
+              name="cardSymbol"
+              value={opt.value}
+              defaultChecked={opt.value === defaultSymbol}
+              className="sr-only"
+            />
+            <EnigmaCardSymbolIcon symbol={opt.value} size="sm" />
+            <span className="text-[11px] font-medium leading-tight text-foreground/80 sm:text-xs">
+              {opt.label}
+            </span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  )
+}

--- a/app/components/enigma-card-symbol/enigma-card-symbol.component.tsx
+++ b/app/components/enigma-card-symbol/enigma-card-symbol.component.tsx
@@ -1,0 +1,222 @@
+import type { EnigmaCardSymbol } from '~/generated/prisma/enums'
+import { EnigmaCardSymbol as EnigmaCardSymbolValues } from '~/generated/prisma/enums'
+
+const ALL_SYMBOLS = Object.values(EnigmaCardSymbolValues)
+
+export function parseEnigmaCardSymbol(raw: string | null | undefined): EnigmaCardSymbol {
+  if (raw != null && ALL_SYMBOLS.includes(raw as EnigmaCardSymbol)) {
+    return raw as EnigmaCardSymbol
+  }
+  return EnigmaCardSymbolValues.DOOR
+}
+
+export const ENIGMA_CARD_SYMBOL_OPTIONS: ReadonlyArray<{
+  value: EnigmaCardSymbol
+  label: string
+}> = [
+  { value: EnigmaCardSymbolValues.DOOR, label: 'Porta' },
+  { value: EnigmaCardSymbolValues.KEY, label: 'Chave' },
+  { value: EnigmaCardSymbolValues.LOCK, label: 'Cadeado' },
+  { value: EnigmaCardSymbolValues.EYE, label: 'Olho' },
+  { value: EnigmaCardSymbolValues.MOON, label: 'Lua' },
+  { value: EnigmaCardSymbolValues.SCROLL, label: 'Pergaminho' },
+  { value: EnigmaCardSymbolValues.MAGNIFYING_GLASS, label: 'Lupa' },
+  { value: EnigmaCardSymbolValues.QUESTION_MARK, label: 'Interrogação' },
+  { value: EnigmaCardSymbolValues.COMPASS, label: 'Bússola' },
+  { value: EnigmaCardSymbolValues.CRYSTAL_BALL, label: 'Bola de cristal' },
+]
+
+function dimClass(size: 'lg' | 'sm') {
+  return size === 'sm' ? 'h-9 w-9 text-foreground/45' : 'h-16 w-16 text-foreground/40'
+}
+
+export function EnigmaCardSymbolIcon({
+  symbol,
+  size = 'lg',
+}: {
+  symbol: EnigmaCardSymbol
+  size?: 'lg' | 'sm'
+}) {
+  const c = dimClass(size)
+  const stroke = size === 'sm' ? '1.75' : '1.5'
+
+  switch (symbol) {
+    case EnigmaCardSymbolValues.KEY:
+      return (
+        <svg
+          className={c}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <circle cx="7.5" cy="15.5" r="5.5" />
+          <path d="m21 2-9.6 9.6" />
+          <path d="m15.5 7.5 3 3L22 7l-3-3" />
+        </svg>
+      )
+    case EnigmaCardSymbolValues.LOCK:
+      return (
+        <svg
+          className={c}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <rect x="5" y="11" width="14" height="10" rx="2" />
+          <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+        </svg>
+      )
+    case EnigmaCardSymbolValues.EYE:
+      return (
+        <svg
+          className={c}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7-10-7-10-7Z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+      )
+    case EnigmaCardSymbolValues.MOON:
+      return (
+        <svg
+          className={c}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M12 3a6.5 6.5 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+        </svg>
+      )
+    case EnigmaCardSymbolValues.SCROLL:
+      return (
+        <svg
+          className={c}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M8 21h8a2 2 0 0 0 2-2v-9H8v11Z" />
+          <path d="M6 3h12v7H6a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2" />
+          <path d="M10 7h4" />
+          <path d="M10 11h4" />
+        </svg>
+      )
+    case EnigmaCardSymbolValues.MAGNIFYING_GLASS:
+      return (
+        <svg
+          className={c}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <circle cx="11" cy="11" r="7" />
+          <path d="m20 20-3.5-3.5" />
+        </svg>
+      )
+    case EnigmaCardSymbolValues.QUESTION_MARK:
+      return (
+        <svg
+          className={c}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M9.09 9a3 3 0 1 1 5.83 1c0 2-3 2-3 4" />
+          <path d="M12 17h.01" />
+        </svg>
+      )
+    case EnigmaCardSymbolValues.COMPASS:
+      return (
+        <svg
+          className={c}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="m16.2 7.8-2.3 6.1a2 2 0 0 1-1.1 1.1l-6.1 2.3 2.3-6.1a2 2 0 0 1 1.1-1.1z" />
+        </svg>
+      )
+    case EnigmaCardSymbolValues.CRYSTAL_BALL:
+      return (
+        <svg
+          className={c}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M12 3a7 7 0 1 0 0 12 7 7 0 0 0 0-12Z" />
+          <path d="M12 15v6" />
+          <path d="M8 21h8" />
+          <path d="M10 7h.01M14 7h.01M12 11h.01" />
+        </svg>
+      )
+    case EnigmaCardSymbolValues.DOOR:
+    default:
+      return (
+        <svg
+          className={c}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M3 21h18" />
+          <path d="M6 21V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v16" />
+          <path d="M14 9v6" />
+        </svg>
+      )
+  }
+}

--- a/app/routes/enigmas/route.tsx
+++ b/app/routes/enigmas/route.tsx
@@ -4,8 +4,13 @@ import Center from '~/components/center/center.component'
 import EnigmasDetectiveFlamingo from '~/components/enigmas-detective-flamingo/enigmas-detective-flamingo.component'
 import Link from '~/components/link/link.component'
 import LinkButton from '~/components/link-button/link-button.component'
+import {
+  EnigmaCardSymbolIcon,
+  parseEnigmaCardSymbol,
+} from '~/components/enigma-card-symbol/enigma-card-symbol.component'
 import { countPublicPlayablePhases } from '~/lib/enigma-public-phases.server'
 import { enigmaRobotsMeta } from '~/lib/enigma-robots-meta'
+import type { EnigmaCardSymbol } from '~/generated/prisma/enums'
 import { Role } from '~/generated/prisma/enums'
 
 export function meta() {
@@ -39,10 +44,12 @@ export async function loader({ context }: Route.LoaderArgs) {
   }
 }
 
-function DoorIcon() {
+function DoorIcon({ size = 'lg' }: { size?: 'lg' | 'sm' }) {
+  const dim =
+    size === 'sm' ? 'h-9 w-9 text-foreground/45' : 'h-16 w-16 text-foreground/40'
   return (
     <svg
-      className="h-16 w-16 text-foreground/40"
+      className={dim}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
       fill="none"
@@ -128,26 +135,33 @@ function EnigmaDoorCard({
   enigma,
   isAdmin,
 }: {
-  enigma: { id: number; name: string; slug: string; _count: { phases: number } }
+  enigma: {
+    id: number
+    name: string
+    slug: string
+    cardSymbol: EnigmaCardSymbol
+    _count: { phases: number }
+  }
   isAdmin: boolean
 }) {
   const phaseCount = enigma._count.phases
   const isPlayable = phaseCount > 0
+  const symbol = parseEnigmaCardSymbol(enigma.cardSymbol)
 
   return (
     <Link
       to={isPlayable ? `/enigmas/${enigma.slug}/entrada` : '#'}
       viewTransition
-      className={`group relative block md:z-[2] ${!isPlayable ? 'pointer-events-none opacity-60' : ''}`}
+      className={`group relative z-[2] block ${!isPlayable ? 'pointer-events-none opacity-60' : ''}`}
     >
-      <div className="relative overflow-hidden rounded-2xl border-2 border-foreground/20 bg-gradient-to-b from-foreground/5 to-foreground/10 p-10 shadow-lg transition-all duration-300 hover:border-primary/40 hover:shadow-xl hover:shadow-primary/5 md:bg-none md:bg-background md:p-14 md:shadow-xl">
+      <div className="relative overflow-hidden rounded-2xl border-2 border-foreground/20 bg-background p-10 shadow-lg transition-all duration-300 hover:border-primary/40 hover:shadow-xl hover:shadow-primary/5 md:p-14 md:shadow-xl">
         {/* Moldura da porta */}
-        <div className="absolute inset-3 rounded-xl border border-foreground/10 md:border-foreground/15" aria-hidden />
+        <div className="absolute inset-3 rounded-xl border border-foreground/15" aria-hidden />
 
         {/* Maçaneta / elemento central */}
         <div className="mb-6 flex justify-center">
-          <div className="flex h-24 w-24 items-center justify-center rounded-full border-2 border-foreground/20 bg-foreground/5 transition-transform duration-300 group-hover:scale-110 group-hover:border-primary/30 md:border-foreground/25 md:bg-foreground/10">
-            <DoorIcon />
+          <div className="flex h-24 w-24 items-center justify-center rounded-full border-2 border-foreground/25 bg-[color-mix(in_srgb,var(--color-on-background)_12%,var(--color-background))] transition-transform duration-300 group-hover:scale-110 group-hover:border-primary/30">
+            <EnigmaCardSymbolIcon symbol={symbol} />
           </div>
         </div>
 
@@ -182,6 +196,86 @@ function EnigmaDoorCard({
         )}
       </div>
     </Link>
+  )
+}
+
+function AdminEnigmaManageList({
+  enigmas,
+}: {
+  enigmas: Array<{
+    id: number
+    name: string
+    slug: string
+    published: boolean
+    cardSymbol: EnigmaCardSymbol
+    _count: { phases: number }
+  }>
+}) {
+  return (
+    <section
+      className="relative z-[2] mx-auto mt-10 w-full max-w-md"
+      aria-labelledby="admin-enigmas-manage-heading"
+    >
+      <h2
+        id="admin-enigmas-manage-heading"
+        className="mb-5 text-center font-brand text-xl font-semibold uppercase tracking-[0.16em] text-foreground/60 sm:text-2xl sm:tracking-[0.14em] md:text-3xl"
+      >
+        Editar enigmas
+      </h2>
+      <ul className="flex flex-col gap-3">
+        {enigmas.map((enigma) => {
+          const phases = enigma._count.phases
+          const phaseLabel =
+            phases === 0
+              ? 'Sem fases'
+              : phases === 1
+                ? '1 fase'
+                : `${phases} fases`
+
+          return (
+            <li key={enigma.id}>
+              <Link
+                to={`/enigmas/${enigma.slug}/edit`}
+                viewTransition
+                className="flex items-stretch gap-3 rounded-2xl border-2 border-foreground/20 bg-background p-3 shadow-md transition-colors hover:border-primary/45 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              >
+                <div
+                  className="flex w-14 shrink-0 flex-col items-center justify-center rounded-xl border border-foreground/15 bg-[color-mix(in_srgb,var(--color-on-background)_10%,var(--color-background))]"
+                  aria-hidden
+                >
+                  <EnigmaCardSymbolIcon
+                    symbol={parseEnigmaCardSymbol(enigma.cardSymbol)}
+                    size="sm"
+                  />
+                </div>
+                <div className="min-w-0 flex-1 py-0.5">
+                  <div className="flex flex-wrap items-center gap-2 gap-y-1">
+                    <span className="font-brand text-lg font-semibold leading-tight text-foreground">
+                      {enigma.name}
+                    </span>
+                    {enigma.published ? (
+                      <span className="shrink-0 rounded-md border border-foreground/20 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-foreground/70">
+                        Publicado
+                      </span>
+                    ) : (
+                      <span className="shrink-0 rounded-md border border-foreground/25 bg-[color-mix(in_srgb,var(--color-on-background)_8%,var(--color-background))] px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-foreground/75">
+                        Rascunho
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1 text-xs text-foreground/40">{phaseLabel}</p>
+                </div>
+                <div className="flex shrink-0 items-center">
+                  <span className="rounded-lg bg-primary px-3 py-2 text-center text-xs font-bold uppercase tracking-wide text-on-primary sm:px-4 sm:text-sm">
+                    Editar
+                  </span>
+                </div>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
   )
 }
 
@@ -256,7 +350,7 @@ export default function Route({ loaderData }: Route.ComponentProps) {
           )}
 
           {loaderData.enigmas.length === 0 ? (
-            <div className="rounded-2xl border-2 border-dashed border-foreground/20 bg-foreground/5 px-6 py-20 text-center">
+            <div className="relative z-[2] rounded-2xl border-2 border-dashed border-foreground/20 bg-background px-6 py-20 text-center shadow-lg">
               <DoorIcon />
               <p className="mt-4 text-foreground/60">
                 {isAdmin
@@ -278,20 +372,7 @@ export default function Route({ loaderData }: Route.ComponentProps) {
           )}
 
           {isAdmin && loaderData.enigmas.length > 0 && (
-            <div className="mt-8 rounded-2xl border border-foreground/10 bg-background/60 p-6 shadow-sm">
-              <div className="flex flex-wrap justify-center gap-4">
-                {loaderData.enigmas.map((enigma) => (
-                  <Link
-                    key={enigma.id}
-                    to={`/enigmas/${enigma.slug}/edit`}
-                    viewTransition
-                    className="text-base font-semibold text-foreground/60 underline-offset-2 hover:text-foreground/90 hover:underline"
-                  >
-                    Gerenciar: {enigma.name}
-                  </Link>
-                ))}
-              </div>
-            </div>
+            <AdminEnigmaManageList enigmas={loaderData.enigmas} />
           )}
         </div>
         </Center>

--- a/app/routes/enigmas_.$slug_.edit/route.tsx
+++ b/app/routes/enigmas_.$slug_.edit/route.tsx
@@ -13,8 +13,11 @@ import Center from '~/components/center/center.component'
 import Link from '~/components/link/link.component'
 import LinkButton from '~/components/link-button/link-button.component'
 import TextInput from '~/components/text-input/text-input.component'
+import { EnigmaCardSymbolFormField } from '~/components/enigma-card-symbol/enigma-card-symbol-form-field.component'
+import { parseEnigmaCardSymbol } from '~/components/enigma-card-symbol/enigma-card-symbol.component'
 import { enigmaPlayPathForPhaseIndex } from '~/lib/enigma-phase-play-path'
 import { enigmaRobotsMeta } from '~/lib/enigma-robots-meta'
+import type { EnigmaCardSymbol } from '~/generated/prisma/enums'
 import { Role } from '~/generated/prisma/enums'
 import bcrypt from 'bcrypt'
 
@@ -134,6 +137,9 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     }
     const publicPhaseOrderFrom = parseOptOrder(formData.get('publicPhaseOrderFrom'))
     const publicPhaseOrderTo = parseOptOrder(formData.get('publicPhaseOrderTo'))
+    const cardSymbol = parseEnigmaCardSymbol(
+      (formData.get('cardSymbol') as string | null) ?? undefined,
+    )
 
     const existing = await context.prisma.enigma.findUniqueOrThrow({
       where: { slug: params.slug },
@@ -172,6 +178,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     const updatePayload: {
       name: string
       slug: string
+      cardSymbol: EnigmaCardSymbol
       published: boolean
       entrancePasswordPrompt: string | null
       publicPhaseOrderFrom: number | null
@@ -180,6 +187,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     } = {
       name,
       slug,
+      cardSymbol,
       published,
       entrancePasswordPrompt,
       publicPhaseOrderFrom,
@@ -238,6 +246,16 @@ export default function Route({ loaderData }: Route.ComponentProps) {
             <p className="mt-1 text-sm uppercase tracking-[0.2em] text-foreground/50">
               {enigma.name}
             </p>
+            <p className="mt-3 text-sm text-foreground/55">
+              <a
+                href="#enigma-card-symbol-fieldset"
+                className="font-medium text-primary underline decoration-primary/40 underline-offset-2 hover:decoration-primary"
+              >
+                Símbolo do cartão em /enigmas
+              </a>
+              {' — '}
+              escolhe na secção abaixo (no topo do formulário Informações).
+            </p>
           </header>
 
           {/* Informações */}
@@ -254,6 +272,20 @@ export default function Route({ loaderData }: Route.ComponentProps) {
                     {actionData.error}
                   </p>
                 )}
+
+                <EnigmaCardSymbolFormField
+                  defaultSymbol={parseEnigmaCardSymbol(enigma.cardSymbol)}
+                  helperText={
+                    <>
+                      Ícone deste enigma na página{' '}
+                      <span className="font-mono text-foreground/70">/enigmas</span>.
+                      Escolhe um símbolo e confirma com{' '}
+                      <strong className="text-foreground/80">Salvar alterações</strong> no fim
+                      deste formulário.
+                    </>
+                  }
+                />
+
                 <TextInput
                   id="name"
                   name="name"
@@ -270,6 +302,7 @@ export default function Route({ loaderData }: Route.ComponentProps) {
                   required={true}
                   defaultValue={enigma.slug}
                 />
+
                 <label className="flex cursor-pointer items-center gap-4 rounded-xl border-2 border-foreground/20 p-6 transition-colors hover:border-foreground/30 has-[:checked]:border-primary has-[:checked]:bg-primary/5">
                   <input
                     type="checkbox"

--- a/app/routes/enigmas_.$slug_.entrada/route.tsx
+++ b/app/routes/enigmas_.$slug_.entrada/route.tsx
@@ -74,15 +74,14 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
 
   return {
     locked: false as const,
-    enigma,
+    enigmaName: enigma.name,
   }
 }
 
 export function meta({ data }: Route.MetaArgs) {
   const robots = enigmaRobotsMeta()
   if (!data) return [...robots, { title: 'Mazeps' }]
-  const name = 'locked' in data && data.locked ? data.enigmaName : data.enigma.name
-  return [...robots, { title: `${name} | Mazeps` }]
+  return [...robots, { title: `${data.enigmaName} | Mazeps` }]
 }
 
 export async function action({ request, context, params }: Route.ActionArgs) {
@@ -283,8 +282,6 @@ export default function Route({
     )
   }
 
-  const { enigma } = loaderData
-
   return (
     <>
       <BackButtonPortal to="/enigmas" />
@@ -295,7 +292,7 @@ export default function Route({
               Enigma
             </p>
             <h1 className="font-brand text-3xl tracking-wide text-foreground/95">
-              {enigma.name}
+              {loaderData.enigmaName}
             </h1>
           </header>
 

--- a/app/routes/enigmas_.new/route.tsx
+++ b/app/routes/enigmas_.new/route.tsx
@@ -5,8 +5,10 @@ import Button from '~/components/button/button.component'
 import Center from '~/components/center/center.component'
 import LinkButton from '~/components/link-button/link-button.component'
 import TextInput from '~/components/text-input/text-input.component'
+import { EnigmaCardSymbolFormField } from '~/components/enigma-card-symbol/enigma-card-symbol-form-field.component'
+import { parseEnigmaCardSymbol } from '~/components/enigma-card-symbol/enigma-card-symbol.component'
 import { enigmaRobotsMeta } from '~/lib/enigma-robots-meta'
-import { Role } from '~/generated/prisma/enums'
+import { EnigmaCardSymbol, Role } from '~/generated/prisma/enums'
 
 const ICON_CLASS = 'h-5 w-5 shrink-0 text-foreground/50'
 
@@ -77,6 +79,18 @@ export default function Route() {
                 required={true}
                 placeholder="Ex: mistério-labirinto"
               />
+
+              <EnigmaCardSymbolFormField
+                defaultSymbol={EnigmaCardSymbol.DOOR}
+                helperText={
+                  <>
+                    Ícone na listagem{' '}
+                    <span className="font-mono text-foreground/70">/enigmas</span>. Depois podes
+                    mudar em <strong className="text-foreground/80">Gerenciar enigma</strong>.
+                  </>
+                }
+              />
+
               <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
                 <LinkButton
                   to="/enigmas"
@@ -106,8 +120,13 @@ export async function action({ request, context }: Route.ActionArgs) {
   const formData = await request.formData()
   const name = formData.get('name') as string
   const slug = (formData.get('slug') as string).toLowerCase().trim()
+  const cardSymbol = parseEnigmaCardSymbol(
+    (formData.get('cardSymbol') as string | null) ?? undefined,
+  )
 
-  const enigma = await context.prisma.enigma.create({ data: { name, slug } })
+  const enigma = await context.prisma.enigma.create({
+    data: { name, slug, cardSymbol },
+  })
 
   return redirect(`/enigmas/${enigma.slug}/edit`)
 }

--- a/prisma/migrations/20260414125409_add_enigma_card_symbol/migration.sql
+++ b/prisma/migrations/20260414125409_add_enigma_card_symbol/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "public"."EnigmaCardSymbol" AS ENUM ('DOOR', 'KEY', 'LOCK', 'EYE', 'MOON', 'SCROLL', 'MAGNIFYING_GLASS', 'QUESTION_MARK', 'COMPASS', 'CRYSTAL_BALL');
+
+-- AlterTable
+ALTER TABLE "public"."Enigma" ADD COLUMN     "cardSymbol" "public"."EnigmaCardSymbol" NOT NULL DEFAULT 'DOOR';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -199,12 +199,27 @@ model MatchResult {
   @@index([playerId, matchId])
 }
 
+enum EnigmaCardSymbol {
+  DOOR
+  KEY
+  LOCK
+  EYE
+  MOON
+  SCROLL
+  MAGNIFYING_GLASS
+  QUESTION_MARK
+  COMPASS
+  CRYSTAL_BALL
+}
+
 model Enigma {
   id        Int           @id @default(autoincrement())
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt
   name      String
   slug      String        @unique
+  /// Ícone exibido no cartão na listagem /enigmas
+  cardSymbol EnigmaCardSymbol @default(DOOR)
   published Boolean       @default(false)
   /// Ordem inclusiva visível ao público (com `published`); null = desde a menor ordem existente
   publicPhaseOrderFrom Int?


### PR DESCRIPTION
- Add EnigmaCardSymbol enum + migration; picker on create/edit; icons on /enigmas cards and admin list

- Improve Editar enigmas section layout; solid card layering tweaks

- Stop serializing full enigma (phases[].answer) on /entrada when unlocked

Made-with: Cursor