### PR TITLE
feat(enigmas): rate limits, lighter play queries, cookies, editor UX

### DIFF
--- a/app/components/enigma-phase-editor-error-banner/enigma-phase-editor-error-banner.component.tsx
+++ b/app/components/enigma-phase-editor-error-banner/enigma-phase-editor-error-banner.component.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react'
+
+function AlertOctagonIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2" />
+      <line x1="12" x2="12" y1="8" y2="12" />
+      <line x1="12" x2="12.01" y1="16" y2="16" />
+    </svg>
+  )
+}
+
+/** Aviso de erro no editor de fase: destaque forte e scroll até ficar visível no topo. */
+export default function EnigmaPhaseEditorErrorBanner({
+  message,
+}: {
+  message: string | undefined
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!message) return
+    const t = window.setTimeout(() => {
+      const el = ref.current
+      if (!el) return
+      el.focus({ preventScroll: true })
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, 0)
+    return () => window.clearTimeout(t)
+  }, [message])
+
+  if (!message) return null
+
+  return (
+    <div
+      ref={ref}
+      tabIndex={-1}
+      className="mb-6 scroll-mt-6 outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      role="alert"
+      aria-live="assertive"
+    >
+      <div className="flex gap-4 rounded-xl border-2 border-red-600 bg-red-50 px-5 py-4 shadow-[0_0_0_1px_rgba(220,38,38,0.15),0_12px_40px_-12px_rgba(185,28,28,0.45)] dark:border-red-500 dark:bg-red-950/90 dark:shadow-[0_0_0_1px_rgba(248,113,113,0.2),0_12px_40px_-12px_rgba(0,0,0,0.5)]">
+        <AlertOctagonIcon className="mt-0.5 h-7 w-7 shrink-0 text-red-600 dark:text-red-400" />
+        <p className="min-w-0 text-base leading-snug font-semibold text-red-900 dark:text-red-50">
+          {message}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/components/enigma-phase-form/enigma-phase-form.component.tsx
+++ b/app/components/enigma-phase-form/enigma-phase-form.component.tsx
@@ -45,6 +45,8 @@ interface EnigmaPhaseFormProps {
   submitLabel: string
   /** Na edição: resposta num bloco destacado no fim (acima do envio / zona de perigo). */
   prominentAnswerSection?: boolean
+  /** Evita duplo envio enquanto o pedido está a ser processado. */
+  submitDisabled?: boolean
 }
 
 const MEDIA_TYPE_OPTIONS = [
@@ -161,6 +163,7 @@ export default function EnigmaPhaseForm({
   defaultValues,
   submitLabel,
   prominentAnswerSection = false,
+  submitDisabled = false,
 }: EnigmaPhaseFormProps) {
   const [mediaType, setMediaType] = useState<string>(
     defaultValues?.mediaType ?? 'NONE',
@@ -747,7 +750,13 @@ export default function EnigmaPhaseForm({
 
       <Spacer size="md" />
 
-      <Button type="submit">{submitLabel}</Button>
+      <Button
+        type="submit"
+        disabled={submitDisabled}
+        className="disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {submitLabel}
+      </Button>
     </>
   )
 }

--- a/app/components/enigma-phase-play/enigma-phase-play.component.tsx
+++ b/app/components/enigma-phase-play/enigma-phase-play.component.tsx
@@ -29,6 +29,7 @@ export type EnigmaPhasePlayLoaderData = {
 
 type EnigmaPhasePlayActionResult =
   | { wrong?: true }
+  | { tooManyAttempts?: true }
   | { whiteScreen?: true; message?: string }
 
 function renderMediaBlock(
@@ -107,16 +108,17 @@ export default function EnigmaPhasePlay({
     if (!d) return
     if ('whiteScreen' in d && d.whiteScreen && typeof d.message === 'string') {
       queueMicrotask(() => whiteScreenDialogRef.current?.showModal())
-      return
-    }
-    if ('wrong' in d && d.wrong) {
-      alert('Resposta incorreta!')
-      if (answerRef.current) {
-        answerRef.current.value = ''
-        answerRef.current.focus()
-      }
     }
   }, [fetcher.data])
+
+  useEffect(() => {
+    const d = fetcher.data
+    if (!d || fetcher.state !== 'idle') return
+    if ('wrong' in d && d.wrong && answerRef.current) {
+      answerRef.current.value = ''
+      answerRef.current.focus()
+    }
+  }, [fetcher.data, fetcher.state])
 
   useEffect(() => {
     if (answerRef.current) {
@@ -141,6 +143,16 @@ export default function EnigmaPhasePlay({
     fetcher.data && 'whiteScreen' in fetcher.data && fetcher.data.whiteScreen
       ? fetcher.data.message
       : undefined
+
+  const submitBusy = fetcher.state !== 'idle'
+  const answerError =
+    fetcher.state === 'idle' && fetcher.data
+      ? 'tooManyAttempts' in fetcher.data && fetcher.data.tooManyAttempts
+        ? 'Muitas tentativas. Aguarda cerca de um minuto e tenta de novo.'
+        : 'wrong' in fetcher.data && fetcher.data.wrong
+          ? 'Resposta incorreta.'
+          : null
+      : null
 
   return (
     <div className="flex w-full flex-col items-center gap-4 px-6 py-2 pb-8">
@@ -263,11 +275,18 @@ export default function EnigmaPhasePlay({
           type="text"
           required
           autoComplete="off"
-          className="w-48 rounded-md border-1 p-1 text-center"
+          disabled={submitBusy}
+          className="w-48 rounded-md border-1 p-1 text-center disabled:opacity-60"
         />
+        {answerError ? (
+          <p className="text-center text-sm text-red-600" role="alert">
+            {answerError}
+          </p>
+        ) : null}
         <button
           type="submit"
-          className="active:pressed cursor-pointer rounded-md bg-primary px-6 py-2 text-on-primary hover:opacity-90"
+          disabled={submitBusy}
+          className="active:pressed cursor-pointer rounded-md bg-primary px-6 py-2 text-on-primary hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
         >
           Enviar
         </button>

--- a/app/lib/enigma-answer-rate-limit.server.ts
+++ b/app/lib/enigma-answer-rate-limit.server.ts
@@ -1,0 +1,39 @@
+import { getClientIp } from '~/lib/request-ip.server'
+
+/** Janela deslizante: tentativas de resposta por IP + enigma. */
+const WINDOW_MS = 60_000
+const MAX_ATTEMPTS = 24
+
+const buckets = new Map<string, number[]>()
+
+function trimBucket(key: string, now: number): number[] {
+  const arr = buckets.get(key) ?? []
+  return arr.filter((t) => now - t < WINDOW_MS)
+}
+
+/**
+ * @returns `false` se excedeu o limite (ação deve responder 429 / mensagem).
+ */
+export function allowEnigmaAnswerAttempt(request: Request, slug: string): boolean {
+  const ip = getClientIp(request)
+  const key = `${ip}:${slug}`
+  const now = Date.now()
+  const recent = trimBucket(key, now)
+  if (recent.length >= MAX_ATTEMPTS) {
+    buckets.set(key, recent)
+    return false
+  }
+  recent.push(now)
+  buckets.set(key, recent)
+
+  /** Evictar chaves mais antigas no Map — nunca limpar tudo (resetava limites de todos os IPs). */
+  if (buckets.size > 15_000) {
+    const target = 10_000
+    while (buckets.size > target) {
+      const k = buckets.keys().next().value
+      if (k === undefined) break
+      buckets.delete(k)
+    }
+  }
+  return true
+}

--- a/app/lib/enigma-celebration-cookie.server.ts
+++ b/app/lib/enigma-celebration-cookie.server.ts
@@ -1,0 +1,134 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import { createCookie, redirect } from 'react-router'
+import type { Enigma } from '~/generated/prisma/client'
+import { userBypassesEnigmaCelebrationPreviewGate } from '~/lib/enigma-entrance-access.server'
+import {
+  getPlayablePhasesOrdered,
+  hasMorePhasesAfterPlayableWindow,
+} from '~/lib/enigma-public-phases.server'
+
+if (!process.env.SESSION_SECRET) {
+  throw new Error('SESSION_SECRET is not defined')
+}
+
+const COOKIE_SECRET = process.env.SESSION_SECRET
+
+export const enigmaCelebrationCookie = createCookie('enigma_celebration', {
+  httpOnly: true,
+  maxAge: 60 * 60 * 24 * 7,
+  path: '/',
+  sameSite: 'lax',
+  secure: process.env.NODE_ENV === 'production',
+  secrets: [COOKIE_SECRET],
+})
+
+export type EnigmaCelebrationKind = 'full' | 'interlude'
+
+type CelebrationMap = Record<string, string>
+
+function celebrationHmacKey() {
+  return `${COOKIE_SECRET}:enigma_celebration`
+}
+
+export function makeCelebrationToken(
+  slug: string,
+  enigmaId: number,
+  kind: EnigmaCelebrationKind,
+): string {
+  const h = createHmac('sha256', celebrationHmacKey())
+  h.update(`${slug}:${enigmaId}:${kind}`)
+  return h.digest('hex')
+}
+
+export async function parseCelebrationMap(
+  request: Request,
+): Promise<CelebrationMap | null> {
+  const raw = await enigmaCelebrationCookie.parse(request.headers.get('Cookie'), {})
+  if (!raw || typeof raw !== 'object') return null
+  return raw as CelebrationMap
+}
+
+export function verifyCelebrationToken(
+  map: CelebrationMap | null,
+  slug: string,
+  enigmaId: number,
+  kind: EnigmaCelebrationKind,
+): boolean {
+  if (!map) return false
+  const token = map[slug]
+  if (typeof token !== 'string') return false
+  const expected = makeCelebrationToken(slug, enigmaId, kind)
+  if (token.length !== expected.length) return false
+  try {
+    return timingSafeEqual(Buffer.from(token, 'utf8'), Buffer.from(expected, 'utf8'))
+  } catch {
+    return false
+  }
+}
+
+export async function setCelebrationCookieHeader(
+  request: Request,
+  slug: string,
+  enigmaId: number,
+  kind: EnigmaCelebrationKind,
+): Promise<string> {
+  const prev = await parseCelebrationMap(request)
+  const token = makeCelebrationToken(slug, enigmaId, kind)
+  const next: CelebrationMap = { ...(prev ?? {}), [slug]: token }
+  return enigmaCelebrationCookie.serialize(next)
+}
+
+/** Só ADMIN pode pré-visualizar parabéns / interlúdio sem cookie (papel da sessão). */
+export async function canAccessCelebrationScreen(
+  request: Request,
+  currentUser: { role?: string } | undefined,
+  slug: string,
+  enigmaId: number,
+  kind: EnigmaCelebrationKind,
+): Promise<boolean> {
+  if (userBypassesEnigmaCelebrationPreviewGate(currentUser?.role)) return true
+  const map = await parseCelebrationMap(request)
+  return verifyCelebrationToken(map, slug, enigmaId, kind)
+}
+
+type EnigmaForParabensGate = Pick<
+  Enigma,
+  'id' | 'published' | 'publicPhaseOrderFrom' | 'publicPhaseOrderTo'
+> & {
+  phases: readonly { order: number }[]
+}
+
+/**
+ * Parabéns: cookie `full`, ou cookie `interlude` quando já não há fases após a janela pública
+ * (ex.: redirecionamento desde /mais-por-vir após mudança de configuração).
+ */
+export async function canAccessParabensScreen(
+  request: Request,
+  currentUser: { role?: string } | undefined,
+  slug: string,
+  enigma: EnigmaForParabensGate,
+  userRole: string | undefined,
+): Promise<boolean> {
+  if (userBypassesEnigmaCelebrationPreviewGate(currentUser?.role)) return true
+  const playable = getPlayablePhasesOrdered(enigma, [...enigma.phases], userRole)
+  const map = await parseCelebrationMap(request)
+  if (verifyCelebrationToken(map, slug, enigma.id, 'full')) return true
+  if (
+    verifyCelebrationToken(map, slug, enigma.id, 'interlude') &&
+    !hasMorePhasesAfterPlayableWindow(enigma.phases, playable)
+  ) {
+    return true
+  }
+  return false
+}
+
+export async function redirectWithCelebrationCookie(
+  url: string,
+  request: Request,
+  slug: string,
+  enigmaId: number,
+  kind: EnigmaCelebrationKind,
+): Promise<Response> {
+  const cookie = await setCelebrationCookieHeader(request, slug, enigmaId, kind)
+  return redirect(url, { headers: { 'Set-Cookie': cookie } })
+}

--- a/app/lib/enigma-entrance-access.server.ts
+++ b/app/lib/enigma-entrance-access.server.ts
@@ -75,11 +75,6 @@ export function verifyEnigmaUnlockFromMap(
   }
 }
 
-export type EnigmaPlayAccessContext = {
-  prisma: PrismaClient
-  userId: number
-}
-
 /** Sessão pode estar desatualizada após mudança de papel no banco. */
 export async function userBypassesEnigmaPasswordGateLive(
   prisma: PrismaClient,
@@ -96,23 +91,22 @@ export async function userBypassesEnigmaPasswordGateLive(
   return userBypassesEnigmaPasswordGate(row?.role)
 }
 
+/** Só ADMIN ignora o cookie de parabéns / mais-por-vir. STAFF segue o fluxo como jogador. */
+export function userBypassesEnigmaCelebrationPreviewGate(
+  role: string | undefined,
+): boolean {
+  if (role == null || role === '') return false
+  return String(role).trim().toUpperCase() === Role.ADMIN
+}
+
 export async function hasEnigmaPlayAccess(
   request: Request,
   enigma: Pick<Enigma, 'id' | 'slug' | 'entrancePasswordHash'>,
   userRole: string | undefined,
-  accessContext?: EnigmaPlayAccessContext,
 ): Promise<boolean> {
   if (!enigma.entrancePasswordHash) return true
 
-  const bypass =
-    accessContext?.prisma && Number.isFinite(accessContext.userId)
-      ? await userBypassesEnigmaPasswordGateLive(accessContext.prisma, {
-          id: accessContext.userId,
-          role: userRole,
-        })
-      : userBypassesEnigmaPasswordGate(userRole)
-
-  if (bypass) return true
+  if (userBypassesEnigmaPasswordGate(userRole)) return true
 
   const map = await parseEnigmaUnlockMap(request)
   return verifyEnigmaUnlockFromMap(map, enigma.slug, enigma.id, enigma.entrancePasswordHash)

--- a/app/lib/enigma-phase-answer.server.ts
+++ b/app/lib/enigma-phase-answer.server.ts
@@ -4,6 +4,23 @@ export function normalizeEnigmaAnswerInput(str: string) {
   return str.trim().toLowerCase()
 }
 
+/** Mensagem ao gravar fase cuja resposta colide com outra do mesmo enigma (após normalizar). */
+export const ENIGMA_PHASE_DUPLICATE_ANSWER_ERROR =
+  'Já existe uma fase com essa resposta!'
+
+export function phaseAnswerConflictsWithSiblingPhases(
+  phases: { id: number; answer: string }[],
+  candidateAnswer: string,
+  excludePhaseId?: number,
+): boolean {
+  const n = normalizeEnigmaAnswerInput(candidateAnswer)
+  return phases.some(
+    (p) =>
+      (excludePhaseId === undefined || p.id !== excludePhaseId) &&
+      normalizeEnigmaAnswerInput(p.answer) === n,
+  )
+}
+
 export type PhaseAnswerResolution =
   | { kind: 'correct' }
   | { kind: 'wrong' }

--- a/app/lib/enigma-play-queries.server.ts
+++ b/app/lib/enigma-play-queries.server.ts
@@ -1,0 +1,63 @@
+import type { PrismaClient } from '~/generated/prisma/client'
+
+/** Metadados do enigma + fases leves (id, ordem, resposta) para encadear URLs e janela pública. */
+export async function loadEnigmaLightForPlay(
+  prisma: PrismaClient,
+  slug: string,
+) {
+  return prisma.enigma.findUnique({
+    where: { slug },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      published: true,
+      publicPhaseOrderFrom: true,
+      publicPhaseOrderTo: true,
+      entrancePasswordHash: true,
+      entrancePasswordPrompt: true,
+      phases: {
+        orderBy: { order: 'asc' },
+        select: {
+          id: true,
+          order: true,
+          answer: true,
+        },
+      },
+    },
+  })
+}
+
+const phasePlayPayloadSelect = {
+  id: true,
+  enigmaId: true,
+  order: true,
+  title: true,
+  pageTitle: true,
+  phrase: true,
+  mediaType: true,
+  mediaUrl: true,
+  imageAlt: true,
+  tipPhrase: true,
+  hiddenHint: true,
+  extraMediaBlocks: true,
+  extraPhrases: true,
+  extraTipPhrases: true,
+  extraHiddenHints: true,
+  whiteScreenHints: true,
+  answer: true,
+} as const
+
+export type EnigmaPhasePlayPayload = NonNullable<
+  Awaited<ReturnType<typeof loadEnigmaPhasePlayPayload>>
+>
+
+export async function loadEnigmaPhasePlayPayload(
+  prisma: PrismaClient,
+  phaseId: number,
+) {
+  return prisma.enigmaPhase.findUnique({
+    where: { id: phaseId },
+    select: phasePlayPayloadSelect,
+  })
+}

--- a/app/lib/request-ip.server.ts
+++ b/app/lib/request-ip.server.ts
@@ -1,0 +1,13 @@
+/** IP do cliente para rate limiting (proxies / Fly). */
+export function getClientIp(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for')
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim()
+    if (first) return first
+  }
+  const fly = request.headers.get('fly-client-ip')
+  if (fly?.trim()) return fly.trim()
+  const real = request.headers.get('x-real-ip')
+  if (real?.trim()) return real.trim()
+  return 'unknown'
+}

--- a/app/routes/enigmas/route.tsx
+++ b/app/routes/enigmas/route.tsx
@@ -20,6 +20,31 @@ export function meta() {
 export async function loader({ context }: Route.LoaderArgs) {
   const isAdmin = context.currentUser?.role === Role.ADMIN
 
+  if (!context.currentUser) {
+    const publishedCandidates = await context.prisma.enigma.findMany({
+      where: { published: true },
+      select: {
+        published: true,
+        publicPhaseOrderFrom: true,
+        publicPhaseOrderTo: true,
+        phases: { select: { order: true } },
+      },
+    })
+    const hasPublishedEnigmas = publishedCandidates.some(
+      (e) =>
+        countPublicPlayablePhases(
+          e,
+          e.phases.map((p) => p.order),
+        ) > 0,
+    )
+    return {
+      enigmas: [],
+      hasPublishedEnigmas,
+      currentUser: null,
+      guestGate: true as const,
+    }
+  }
+
   const enigmas = await context.prisma.enigma.findMany({
     include: {
       _count: { select: { phases: true } },
@@ -41,6 +66,7 @@ export async function loader({ context }: Route.LoaderArgs) {
     enigmas: isAdmin ? enigmas : publishedEnigmas,
     hasPublishedEnigmas: publishedEnigmas.length > 0,
     currentUser: context.currentUser,
+    guestGate: false as const,
   }
 }
 
@@ -68,6 +94,29 @@ function DoorIcon({ size = 'lg' }: { size?: 'lg' | 'sm' }) {
 function EnigmasFlamingoBackdrop() {
   return (
     <EnigmasDetectiveFlamingo className="fixed bottom-3 left-0 z-0 w-[min(24vw,96px)] max-w-[96px] -translate-x-[14%] opacity-75 drop-shadow-[0_6px_16px_rgba(0,0,0,0.12)] sm:bottom-auto sm:top-24 sm:w-[min(92vw,420px)] sm:max-w-[420px] sm:-translate-x-[54%] sm:opacity-[0.94] sm:drop-shadow-[0_12px_32px_rgba(0,0,0,0.16)] md:top-28 md:w-[440px] md:max-w-[440px] md:-translate-x-[52%] lg:w-[480px] lg:max-w-[480px] lg:-translate-x-[50%]" />
+  )
+}
+
+/** Visitante sem login: decoração atrás do overlay, sem nomes/slugs dos enigmas. */
+function GuestMysteryDoorsBackdrop() {
+  return (
+    <div
+      className="flex flex-col items-center gap-8 opacity-[0.38]"
+      aria-hidden
+    >
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className="w-full max-w-md rounded-2xl border-2 border-foreground/18 bg-background/85 p-10 shadow-inner md:p-14"
+        >
+          <div className="mx-auto mb-6 flex h-24 w-24 items-center justify-center rounded-full border-2 border-foreground/20 bg-[color-mix(in_srgb,var(--color-on-background)_10%,var(--color-background))]">
+            <span className="text-3xl font-light text-foreground/35">?</span>
+          </div>
+          <div className="mx-auto h-7 w-4/5 rounded-md bg-foreground/10" />
+          <div className="mx-auto mt-3 h-4 w-1/2 rounded bg-foreground/8" />
+        </div>
+      ))}
+    </div>
   )
 }
 
@@ -349,7 +398,9 @@ export default function Route({ loaderData }: Route.ComponentProps) {
             </div>
           )}
 
-          {loaderData.enigmas.length === 0 ? (
+          {loaderData.guestGate ? (
+            <GuestMysteryDoorsBackdrop />
+          ) : loaderData.enigmas.length === 0 ? (
             <div className="relative z-[2] rounded-2xl border-2 border-dashed border-foreground/20 bg-background px-6 py-20 text-center shadow-lg">
               <DoorIcon />
               <p className="mt-4 text-foreground/60">

--- a/app/routes/enigmas_.$slug/route.tsx
+++ b/app/routes/enigmas_.$slug/route.tsx
@@ -1,16 +1,22 @@
 import { data, redirect } from 'react-router'
 import type { Route } from './+types/route'
 import EnigmaPhasePlay from '~/components/enigma-phase-play/enigma-phase-play.component'
+import { allowEnigmaAnswerAttempt } from '~/lib/enigma-answer-rate-limit.server'
 import {
   enigmaRequiresEntrancePassword,
   hasEnigmaPlayAccess,
 } from '~/lib/enigma-entrance-access.server'
+import {
+  loadEnigmaLightForPlay,
+  loadEnigmaPhasePlayPayload,
+} from '~/lib/enigma-play-queries.server'
 import {
   toPublicEnigmaPhase,
   toPublicEnigmaPlay,
 } from '~/lib/enigma-play-public'
 import { enigmaRobotsMeta } from '~/lib/enigma-robots-meta'
 import { resolvePhaseAnswerSubmission } from '~/lib/enigma-phase-answer.server'
+import { redirectWithCelebrationCookie } from '~/lib/enigma-celebration-cookie.server'
 import {
   getPlayablePhasesOrdered,
   hasMorePhasesAfterPlayableWindow,
@@ -20,10 +26,7 @@ import { Role } from '~/generated/prisma/enums'
 export async function loader({ context, params, request }: Route.LoaderArgs) {
   const { slug } = params
 
-  const enigma = await context.prisma.enigma.findUnique({
-    where: { slug },
-    include: { phases: { orderBy: { order: 'asc' } } },
-  })
+  const enigma = await loadEnigmaLightForPlay(context.prisma, slug)
 
   if (!enigma) throw new Response('Not Found', { status: 404 })
 
@@ -32,15 +35,10 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     throw new Response('Not Found', { status: 404 })
   }
 
-  const accessCtx =
-    context.currentUser != null
-      ? { prisma: context.prisma, userId: Number(context.currentUser.id) }
-      : undefined
   const canPlay = await hasEnigmaPlayAccess(
     request,
     enigma,
     context.currentUser?.role,
-    accessCtx,
   )
   if (!canPlay && enigmaRequiresEntrancePassword(enigma)) {
     const next = encodeURIComponent(new URL(request.url).pathname)
@@ -52,12 +50,15 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     enigma.phases,
     context.currentUser?.role,
   )
-  const phase = playable[0] ?? null
-  if (!phase) throw new Response('Not Found', { status: 404 })
+  const first = playable[0] ?? null
+  if (!first) throw new Response('Not Found', { status: 404 })
+
+  const phaseFull = await loadEnigmaPhasePlayPayload(context.prisma, first.id)
+  if (!phaseFull) throw new Response('Not Found', { status: 404 })
 
   return {
     enigma: toPublicEnigmaPlay(enigma),
-    phase: toPublicEnigmaPhase(phase),
+    phase: toPublicEnigmaPhase(phaseFull),
     isFinished: false,
     isAdmin: context.currentUser?.role === Role.ADMIN,
   }
@@ -73,10 +74,11 @@ export function meta({ data }: Route.MetaArgs) {
 export async function action({ request, context, params }: Route.ActionArgs) {
   const { slug } = params
 
-  const enigma = await context.prisma.enigma.findUnique({
-    where: { slug },
-    include: { phases: { orderBy: { order: 'asc' } } },
-  })
+  if (!allowEnigmaAnswerAttempt(request, slug)) {
+    return data({ tooManyAttempts: true as const }, { status: 429 })
+  }
+
+  const enigma = await loadEnigmaLightForPlay(context.prisma, slug)
 
   if (!enigma) throw new Response('Not Found', { status: 404 })
 
@@ -85,15 +87,10 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     throw new Response('Not Found', { status: 404 })
   }
 
-  const accessCtxAction =
-    context.currentUser != null
-      ? { prisma: context.prisma, userId: Number(context.currentUser.id) }
-      : undefined
   const canPlay = await hasEnigmaPlayAccess(
     request,
     enigma,
     context.currentUser?.role,
-    accessCtxAction,
   )
   if (!canPlay && enigmaRequiresEntrancePassword(enigma)) {
     const next = encodeURIComponent(new URL(request.url).pathname)
@@ -105,14 +102,17 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     enigma.phases,
     context.currentUser?.role,
   )
-  const phase = playable[0] ?? null
-  if (!phase) throw new Response('Not Found', { status: 404 })
+  const first = playable[0] ?? null
+  if (!first) throw new Response('Not Found', { status: 404 })
+
+  const phaseFull = await loadEnigmaPhasePlayPayload(context.prisma, first.id)
+  if (!phaseFull) throw new Response('Not Found', { status: 404 })
 
   const formData = await request.formData()
   const resolution = resolvePhaseAnswerSubmission({
     submittedRaw: formData.get('answer') as string,
-    correctAnswer: phase.answer,
-    whiteScreenHintsJson: phase.whiteScreenHints,
+    correctAnswer: phaseFull.answer,
+    whiteScreenHintsJson: phaseFull.whiteScreenHints,
   })
 
   if (resolution.kind === 'whiteScreen') {
@@ -122,15 +122,28 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     return data({ wrong: true as const })
   }
 
-  const isLast = phase.order === playable[playable.length - 1]!.order
+  const isLast = phaseFull.order === playable[playable.length - 1]!.order
   if (isLast) {
     if (hasMorePhasesAfterPlayableWindow(enigma.phases, playable)) {
-      return redirect(`/enigmas/${slug}/mais-por-vir`)
+      return redirectWithCelebrationCookie(
+        `/enigmas/${slug}/mais-por-vir`,
+        request,
+        slug,
+        enigma.id,
+        'interlude',
+      )
     }
-    return redirect(`/enigmas/${slug}/parabens`)
+    return redirectWithCelebrationCookie(
+      `/enigmas/${slug}/parabens`,
+      request,
+      slug,
+      enigma.id,
+      'full',
+    )
   }
 
-  return redirect(`/enigmas/${slug}/${phase.answer}`)
+  const segment = encodeURIComponent(phaseFull.answer.trim())
+  return redirect(`/enigmas/${slug}/${segment}`)
 }
 
 export default function Route({ loaderData, params }: Route.ComponentProps) {

--- a/app/routes/enigmas_.$slug_.$phaseKey/route.tsx
+++ b/app/routes/enigmas_.$slug_.$phaseKey/route.tsx
@@ -1,10 +1,15 @@
 import { data, redirect } from 'react-router'
 import type { Route } from './+types/route'
 import EnigmaPhasePlay from '~/components/enigma-phase-play/enigma-phase-play.component'
+import { allowEnigmaAnswerAttempt } from '~/lib/enigma-answer-rate-limit.server'
 import {
   enigmaRequiresEntrancePassword,
   hasEnigmaPlayAccess,
 } from '~/lib/enigma-entrance-access.server'
+import {
+  loadEnigmaLightForPlay,
+  loadEnigmaPhasePlayPayload,
+} from '~/lib/enigma-play-queries.server'
 import {
   toPublicEnigmaPhase,
   toPublicEnigmaPlay,
@@ -15,6 +20,11 @@ import {
   resolvePhaseAnswerSubmission,
 } from '~/lib/enigma-phase-answer.server'
 import {
+  canAccessCelebrationScreen,
+  canAccessParabensScreen,
+  redirectWithCelebrationCookie,
+} from '~/lib/enigma-celebration-cookie.server'
+import {
   getPlayablePhasesOrdered,
   hasMorePhasesAfterPlayableWindow,
 } from '~/lib/enigma-public-phases.server'
@@ -23,10 +33,7 @@ import { Role } from '~/generated/prisma/enums'
 export async function loader({ context, params, request }: Route.LoaderArgs) {
   const { slug, phaseKey } = params
 
-  const enigma = await context.prisma.enigma.findUnique({
-    where: { slug },
-    include: { phases: { orderBy: { order: 'asc' } } },
-  })
+  const enigma = await loadEnigmaLightForPlay(context.prisma, slug)
 
   if (!enigma) throw new Response('Not Found', { status: 404 })
 
@@ -35,15 +42,10 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     throw new Response('Not Found', { status: 404 })
   }
 
-  const accessCtx =
-    context.currentUser != null
-      ? { prisma: context.prisma, userId: Number(context.currentUser.id) }
-      : undefined
   const canPlay = await hasEnigmaPlayAccess(
     request,
     enigma,
     context.currentUser?.role,
-    accessCtx,
   )
   if (!canPlay && enigmaRequiresEntrancePassword(enigma)) {
     const next = encodeURIComponent(new URL(request.url).pathname)
@@ -55,6 +57,14 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
   }
 
   if (phaseKey === 'parabens') {
+    const ok = await canAccessParabensScreen(
+      request,
+      context.currentUser,
+      slug,
+      enigma,
+      context.currentUser?.role,
+    )
+    if (!ok) return redirect(`/enigmas/${slug}`)
     return {
       enigma: toPublicEnigmaPlay(enigma),
       phase: null,
@@ -73,6 +83,14 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     if (!hasMorePhasesAfterPlayableWindow(enigma.phases, playable)) {
       return redirect(`/enigmas/${slug}/parabens`)
     }
+    const ok = await canAccessCelebrationScreen(
+      request,
+      context.currentUser,
+      slug,
+      enigma.id,
+      'interlude',
+    )
+    if (!ok) return redirect(`/enigmas/${slug}`)
     return {
       enigma: toPublicEnigmaPlay(enigma),
       phase: null,
@@ -89,21 +107,26 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
   )
   const playableIds = new Set(playable.map((p) => p.id))
 
-  let phase = null
+  let nextLight: (typeof enigma.phases)[number] | null = null
 
   const keyNorm = normalizeEnigmaAnswerInput(phaseKey!)
   const prevIndex = enigma.phases.findIndex(
     (p) => normalizeEnigmaAnswerInput(p.answer) === keyNorm,
   )
   if (prevIndex !== -1 && prevIndex + 1 < enigma.phases.length) {
-    phase = enigma.phases[prevIndex + 1]
+    nextLight = enigma.phases[prevIndex + 1]!
   }
 
-  if (!phase || !playableIds.has(phase.id)) throw new Response('Not Found', { status: 404 })
+  if (!nextLight || !playableIds.has(nextLight.id)) {
+    throw new Response('Not Found', { status: 404 })
+  }
+
+  const phaseFull = await loadEnigmaPhasePlayPayload(context.prisma, nextLight.id)
+  if (!phaseFull) throw new Response('Not Found', { status: 404 })
 
   return {
     enigma: toPublicEnigmaPlay(enigma),
-    phase: toPublicEnigmaPhase(phase),
+    phase: toPublicEnigmaPhase(phaseFull),
     isFinished: false,
     isAdmin: context.currentUser?.role === Role.ADMIN,
   }
@@ -128,10 +151,11 @@ export function meta({ data }: Route.MetaArgs) {
 export async function action({ request, context, params }: Route.ActionArgs) {
   const { slug, phaseKey } = params
 
-  const enigma = await context.prisma.enigma.findUnique({
-    where: { slug },
-    include: { phases: { orderBy: { order: 'asc' } } },
-  })
+  if (!allowEnigmaAnswerAttempt(request, slug)) {
+    return data({ tooManyAttempts: true as const }, { status: 429 })
+  }
+
+  const enigma = await loadEnigmaLightForPlay(context.prisma, slug)
 
   if (!enigma) throw new Response('Not Found', { status: 404 })
 
@@ -140,15 +164,10 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     throw new Response('Not Found', { status: 404 })
   }
 
-  const accessCtxAction =
-    context.currentUser != null
-      ? { prisma: context.prisma, userId: Number(context.currentUser.id) }
-      : undefined
   const canPlay = await hasEnigmaPlayAccess(
     request,
     enigma,
     context.currentUser?.role,
-    accessCtxAction,
   )
   if (!canPlay && enigmaRequiresEntrancePassword(enigma)) {
     const next = encodeURIComponent(new URL(request.url).pathname)
@@ -170,22 +189,27 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   )
   const playableIds = new Set(playable.map((p) => p.id))
 
-  let phase = null
+  let nextLight: (typeof enigma.phases)[number] | null = null
   const keyNorm = normalizeEnigmaAnswerInput(phaseKey!)
   const prevIndex = enigma.phases.findIndex(
     (p) => normalizeEnigmaAnswerInput(p.answer) === keyNorm,
   )
   if (prevIndex !== -1 && prevIndex + 1 < enigma.phases.length) {
-    phase = enigma.phases[prevIndex + 1]
+    nextLight = enigma.phases[prevIndex + 1]!
   }
 
-  if (!phase || !playableIds.has(phase.id)) throw new Response('Not Found', { status: 404 })
+  if (!nextLight || !playableIds.has(nextLight.id)) {
+    throw new Response('Not Found', { status: 404 })
+  }
+
+  const phaseFull = await loadEnigmaPhasePlayPayload(context.prisma, nextLight.id)
+  if (!phaseFull) throw new Response('Not Found', { status: 404 })
 
   const formData = await request.formData()
   const resolution = resolvePhaseAnswerSubmission({
     submittedRaw: formData.get('answer') as string,
-    correctAnswer: phase.answer,
-    whiteScreenHintsJson: phase.whiteScreenHints,
+    correctAnswer: phaseFull.answer,
+    whiteScreenHintsJson: phaseFull.whiteScreenHints,
   })
 
   if (resolution.kind === 'whiteScreen') {
@@ -195,15 +219,28 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     return data({ wrong: true as const })
   }
 
-  const isLast = phase.order === playable[playable.length - 1]!.order
+  const isLast = phaseFull.order === playable[playable.length - 1]!.order
   if (isLast) {
     if (hasMorePhasesAfterPlayableWindow(enigma.phases, playable)) {
-      return redirect(`/enigmas/${slug}/mais-por-vir`)
+      return redirectWithCelebrationCookie(
+        `/enigmas/${slug}/mais-por-vir`,
+        request,
+        slug,
+        enigma.id,
+        'interlude',
+      )
     }
-    return redirect(`/enigmas/${slug}/parabens`)
+    return redirectWithCelebrationCookie(
+      `/enigmas/${slug}/parabens`,
+      request,
+      slug,
+      enigma.id,
+      'full',
+    )
   }
 
-  return redirect(`/enigmas/${slug}/${phase.answer}`)
+  const segment = encodeURIComponent(phaseFull.answer.trim())
+  return redirect(`/enigmas/${slug}/${segment}`)
 }
 
 export default function Route({ loaderData, params }: Route.ComponentProps) {

--- a/app/routes/enigmas_.$slug_.edit/route.tsx
+++ b/app/routes/enigmas_.$slug_.edit/route.tsx
@@ -5,6 +5,7 @@ import {
   redirect,
   useActionData,
   useFetcher,
+  useNavigation,
 } from 'react-router'
 import type { Route } from './+types/route'
 import BackButtonPortal from '~/components/back-button-portal/back-button-portal.component'
@@ -223,8 +224,12 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 
 export default function Route({ loaderData }: Route.ComponentProps) {
   const fetcher = useFetcher()
+  const navigation = useNavigation()
   const actionData = useActionData<typeof action>()
   const { enigma } = loaderData
+  const navBusy = navigation.state === 'submitting'
+  const fetcherBusy = fetcher.state !== 'idle'
+  const formBusy = navBusy || fetcherBusy
 
   const orderMin = enigma.phases.length
     ? Math.min(...enigma.phases.map((p) => p.order))
@@ -418,7 +423,13 @@ export default function Route({ loaderData }: Route.ComponentProps) {
                 </div>
 
                 <div className="flex justify-end">
-                  <Button type="submit">Salvar alterações</Button>
+                  <Button
+                    type="submit"
+                    disabled={formBusy}
+                    className="disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Salvar alterações
+                  </Button>
                 </div>
               </div>
             </Form>
@@ -487,7 +498,8 @@ export default function Route({ loaderData }: Route.ComponentProps) {
                             <input type="hidden" name="phaseId" value={phase.id} />
                             <button
                               type="submit"
-                              className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30"
+                              disabled={formBusy}
+                              className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-950/30"
                               onClick={(e) => {
                                 if (!confirm('Remover esta fase?')) e.preventDefault()
                               }}
@@ -530,7 +542,8 @@ export default function Route({ loaderData }: Route.ComponentProps) {
               <input type="hidden" name="intent" value="delete-enigma" />
               <button
                 type="submit"
-                className="flex items-center gap-2 rounded-lg border border-red-300 bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 dark:border-red-800 dark:bg-red-700 dark:hover:bg-red-800"
+                disabled={formBusy}
+                className="flex items-center gap-2 rounded-lg border border-red-300 bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-800 dark:bg-red-700 dark:hover:bg-red-800"
                 onClick={(e) => {
                   if (!confirm(`Deletar o enigma "${enigma.name}" permanentemente? Esta ação não pode ser desfeita.`)) e.preventDefault()
                 }}

--- a/app/routes/enigmas_.$slug_.edit_.phases_.$phaseId/route.tsx
+++ b/app/routes/enigmas_.$slug_.edit_.phases_.$phaseId/route.tsx
@@ -1,7 +1,8 @@
-import { data, Form, redirect } from 'react-router'
+import { data, Form, redirect, useNavigation } from 'react-router'
 import type { Route } from './+types/route'
 import BackButtonPortal from '~/components/back-button-portal/back-button-portal.component'
 import Center from '~/components/center/center.component'
+import EnigmaPhaseEditorErrorBanner from '~/components/enigma-phase-editor-error-banner/enigma-phase-editor-error-banner.component'
 import EnigmaPhaseForm from '~/components/enigma-phase-form/enigma-phase-form.component'
 import { enigmaRobotsMeta } from '~/lib/enigma-robots-meta'
 import { saveEnigmaPhaseUpload } from '~/lib/upload'
@@ -10,6 +11,10 @@ import {
   parsePhaseTextExtrasFromForm,
   parseWhiteScreenHintsFromForm,
 } from '~/lib/enigma-phase-form-parse.server'
+import {
+  ENIGMA_PHASE_DUPLICATE_ANSWER_ERROR,
+  phaseAnswerConflictsWithSiblingPhases,
+} from '~/lib/enigma-phase-answer.server'
 import { toYouTubeEmbedUrl } from '~/lib/youtube'
 import { Role } from '~/generated/prisma/enums'
 
@@ -124,6 +129,20 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   const hiddenHintRaw = (formData.get('hiddenHint') as string) ?? ''
   const hiddenHint = hiddenHintRaw.trim() === '' ? null : hiddenHintRaw.trim()
 
+  const siblingPhases = await context.prisma.enigmaPhase.findMany({
+    where: { enigmaId: existingPhase.enigmaId },
+    select: { id: true, answer: true },
+  })
+  if (
+    phaseAnswerConflictsWithSiblingPhases(
+      siblingPhases,
+      answer,
+      existingPhase.id,
+    )
+  ) {
+    return data({ error: ENIGMA_PHASE_DUPLICATE_ANSWER_ERROR }, { status: 400 })
+  }
+
   const textExtras = parsePhaseTextExtrasFromForm(formData)
   const whiteScreenHints = parseWhiteScreenHintsFromForm(formData)
 
@@ -162,6 +181,8 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 }
 
 export default function Route({ loaderData, actionData }: Route.ComponentProps) {
+  const navigation = useNavigation()
+  const formBusy = navigation.state === 'submitting'
   const { phase } = loaderData
 
   return (
@@ -169,14 +190,13 @@ export default function Route({ loaderData, actionData }: Route.ComponentProps) 
       <BackButtonPortal to={`/enigmas/${phase.enigma.slug}/edit`} />
       <Center>
         <div className="mx-auto max-w-2xl px-6 py-10">
-          {actionData && 'error' in actionData && actionData.error ? (
-            <div
-              className="mb-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-100"
-              role="alert"
-            >
-              {actionData.error}
-            </div>
-          ) : null}
+          <EnigmaPhaseEditorErrorBanner
+            message={
+              actionData && 'error' in actionData && actionData.error
+                ? actionData.error
+                : undefined
+            }
+          />
           <header className="mb-8">
             <h1 className="font-brand flex items-center gap-2 text-2xl tracking-wide">
               <PencilIcon />
@@ -211,6 +231,7 @@ export default function Route({ loaderData, actionData }: Route.ComponentProps) 
                   whiteScreenHints: phase.whiteScreenHints,
                 }}
                 submitLabel="Salvar alterações"
+                submitDisabled={formBusy}
               />
             </Form>
           </section>
@@ -226,7 +247,8 @@ export default function Route({ loaderData, actionData }: Route.ComponentProps) 
               <input type="hidden" name="intent" value="delete" />
               <button
                 type="submit"
-                className="flex items-center gap-2 rounded-lg border border-red-300 bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 dark:border-red-800 dark:bg-red-700 dark:hover:bg-red-800"
+                disabled={formBusy}
+                className="flex items-center gap-2 rounded-lg border border-red-300 bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-800 dark:bg-red-700 dark:hover:bg-red-800"
                 onClick={(e) => {
                   if (!confirm('Remover esta fase permanentemente?')) e.preventDefault()
                 }}

--- a/app/routes/enigmas_.$slug_.edit_.phases_.new/route.tsx
+++ b/app/routes/enigmas_.$slug_.edit_.phases_.new/route.tsx
@@ -1,7 +1,8 @@
-import { data, Form, redirect } from 'react-router'
+import { data, Form, redirect, useNavigation } from 'react-router'
 import type { Route } from './+types/route'
 import BackButtonPortal from '~/components/back-button-portal/back-button-portal.component'
 import Center from '~/components/center/center.component'
+import EnigmaPhaseEditorErrorBanner from '~/components/enigma-phase-editor-error-banner/enigma-phase-editor-error-banner.component'
 import EnigmaPhaseForm from '~/components/enigma-phase-form/enigma-phase-form.component'
 import { enigmaRobotsMeta } from '~/lib/enigma-robots-meta'
 import { saveEnigmaPhaseUpload } from '~/lib/upload'
@@ -10,6 +11,10 @@ import {
   parsePhaseTextExtrasFromForm,
   parseWhiteScreenHintsFromForm,
 } from '~/lib/enigma-phase-form-parse.server'
+import {
+  ENIGMA_PHASE_DUPLICATE_ANSWER_ERROR,
+  phaseAnswerConflictsWithSiblingPhases,
+} from '~/lib/enigma-phase-answer.server'
 import { toYouTubeEmbedUrl } from '~/lib/youtube'
 import { Role } from '~/generated/prisma/enums'
 
@@ -92,6 +97,13 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   const imageAlt = (formData.get('imageAlt') as string) || null
   const phrase = formData.get('phrase') as string
   const answer = formData.get('answer') as string
+  const siblingPhases = await context.prisma.enigmaPhase.findMany({
+    where: { enigmaId: enigma.id },
+    select: { id: true, answer: true },
+  })
+  if (phaseAnswerConflictsWithSiblingPhases(siblingPhases, answer)) {
+    return data({ error: ENIGMA_PHASE_DUPLICATE_ANSWER_ERROR }, { status: 400 })
+  }
   const tipPhrase = (formData.get('tipPhrase') as string) || null
   const hiddenHintRaw = (formData.get('hiddenHint') as string) ?? ''
   const hiddenHint = hiddenHintRaw.trim() === '' ? null : hiddenHintRaw.trim()
@@ -133,6 +145,8 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 }
 
 export default function Route({ loaderData, actionData }: Route.ComponentProps) {
+  const navigation = useNavigation()
+  const formBusy = navigation.state === 'submitting'
   const nextOrder = loaderData.enigma._count.phases + 1
 
   return (
@@ -140,14 +154,13 @@ export default function Route({ loaderData, actionData }: Route.ComponentProps) 
       <BackButtonPortal to={`/enigmas/${loaderData.enigma.slug}/edit`} />
       <Center>
         <div className="mx-auto max-w-2xl px-6 py-10">
-          {actionData && 'error' in actionData && actionData.error ? (
-            <div
-              className="mb-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-100"
-              role="alert"
-            >
-              {actionData.error}
-            </div>
-          ) : null}
+          <EnigmaPhaseEditorErrorBanner
+            message={
+              actionData && 'error' in actionData && actionData.error
+                ? actionData.error
+                : undefined
+            }
+          />
           <header className="mb-8">
             <h1 className="font-brand flex items-center gap-2 text-2xl tracking-wide">
               <PlusIcon />
@@ -163,6 +176,7 @@ export default function Route({ loaderData, actionData }: Route.ComponentProps) 
               <EnigmaPhaseForm
                 defaultValues={{ order: nextOrder }}
                 submitLabel="Criar fase"
+                submitDisabled={formBusy}
               />
             </Form>
           </section>

--- a/app/routes/enigmas_.$slug_.entrada/route.tsx
+++ b/app/routes/enigmas_.$slug_.entrada/route.tsx
@@ -1,10 +1,11 @@
-import { data, Form, redirect, useSearchParams } from 'react-router'
+import { data, Form, redirect, useNavigation, useSearchParams } from 'react-router'
 import type { Route } from './+types/route'
 import BackButtonPortal from '~/components/back-button-portal/back-button-portal.component'
 import Button from '~/components/button/button.component'
 import Center from '~/components/center/center.component'
 import LinkButton from '~/components/link-button/link-button.component'
 import { DEFAULT_ENIGMA_ENTRANCE_PROMPT } from '~/lib/enigma-entrance-prompt'
+import { allowEnigmaAnswerAttempt } from '~/lib/enigma-answer-rate-limit.server'
 import {
   enigmaRequiresEntrancePassword,
   hasEnigmaPlayAccess,
@@ -13,7 +14,9 @@ import {
   setEnigmaUnlockCookieHeader,
   userBypassesEnigmaPasswordGateLive,
 } from '~/lib/enigma-entrance-access.server'
+import { loadEnigmaLightForPlay } from '~/lib/enigma-play-queries.server'
 import { enigmaRobotsMeta } from '~/lib/enigma-robots-meta'
+import { redirectWithCelebrationCookie } from '~/lib/enigma-celebration-cookie.server'
 import {
   getPlayablePhasesOrdered,
   hasMorePhasesAfterPlayableWindow,
@@ -28,10 +31,7 @@ function normalize(str: string) {
 export async function loader({ context, params, request }: Route.LoaderArgs) {
   const { slug } = params
 
-  const enigma = await context.prisma.enigma.findUnique({
-    where: { slug },
-    include: { phases: { orderBy: { order: 'asc' } } },
-  })
+  const enigma = await loadEnigmaLightForPlay(context.prisma, slug)
 
   if (!enigma) throw new Response('Not Found', { status: 404 })
 
@@ -44,15 +44,10 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     throw new Response('Not Found', { status: 404 })
   }
 
-  const accessCtx =
-    context.currentUser != null
-      ? { prisma: context.prisma, userId: Number(context.currentUser.id) }
-      : undefined
   const hasAccess = await hasEnigmaPlayAccess(
     request,
     enigma,
     context.currentUser?.role,
-    accessCtx,
   )
   if (!hasAccess && enigmaRequiresEntrancePassword(enigma)) {
     return {
@@ -87,10 +82,7 @@ export function meta({ data }: Route.MetaArgs) {
 export async function action({ request, context, params }: Route.ActionArgs) {
   const { slug } = params
 
-  const enigma = await context.prisma.enigma.findUnique({
-    where: { slug },
-    include: { phases: { orderBy: { order: 'asc' } } },
-  })
+  const enigma = await loadEnigmaLightForPlay(context.prisma, slug)
 
   if (!enigma) throw new Response('Not Found', { status: 404 })
 
@@ -158,20 +150,25 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     })
   }
 
-  const accessCtxPost =
-    context.currentUser != null
-      ? { prisma: context.prisma, userId: Number(context.currentUser.id) }
-      : undefined
   const canPlay = await hasEnigmaPlayAccess(
     request,
     enigma,
     context.currentUser?.role,
-    accessCtxPost,
   )
   if (!canPlay && enigmaRequiresEntrancePassword(enigma)) {
     return data({
       error: 'É necessário informar a senha do enigma antes de continuar.',
     })
+  }
+
+  if (!allowEnigmaAnswerAttempt(request, slug)) {
+    return data(
+      {
+        error:
+          'Muitas tentativas. Aguarda cerca de um minuto e tenta de novo.',
+      },
+      { status: 429 },
+    )
   }
 
   const raw = (formData.get('lastAnswer') as string) ?? ''
@@ -191,9 +188,21 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   const isLast = matchIndex === playable.length - 1
   if (isLast) {
     if (hasMorePhasesAfterPlayableWindow(enigma.phases, playable)) {
-      return redirect(`/enigmas/${slug}/mais-por-vir`)
+      return redirectWithCelebrationCookie(
+        `/enigmas/${slug}/mais-por-vir`,
+        request,
+        slug,
+        enigma.id,
+        'interlude',
+      )
     }
-    return redirect(`/enigmas/${slug}/parabens`)
+    return redirectWithCelebrationCookie(
+      `/enigmas/${slug}/parabens`,
+      request,
+      slug,
+      enigma.id,
+      'full',
+    )
   }
 
   const segment = encodeURIComponent(playable[matchIndex]!.answer.trim())
@@ -204,10 +213,12 @@ function LockedGateView({
   enigmaName,
   prompt,
   actionData,
+  formBusy,
 }: {
   enigmaName: string
   prompt: string
   actionData: Route.ComponentProps['actionData']
+  formBusy: boolean
 }) {
   const [searchParams] = useSearchParams()
   const next = searchParams.get('next') ?? ''
@@ -248,7 +259,8 @@ function LockedGateView({
                   name="password"
                   type="password"
                   autoComplete="off"
-                  className="w-full rounded-md border-1 p-2"
+                  disabled={formBusy}
+                  className="w-full rounded-md border-1 p-2 disabled:cursor-not-allowed disabled:opacity-60"
                   placeholder="Senha"
                 />
                 {actionData?.error && (
@@ -256,7 +268,11 @@ function LockedGateView({
                     {actionData.error}
                   </p>
                 )}
-              <Button type="submit" className="w-full py-3 text-base font-semibold">
+              <Button
+                type="submit"
+                disabled={formBusy}
+                className="w-full py-3 text-base font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+              >
                 Entrar
               </Button>
             </Form>
@@ -272,12 +288,16 @@ export default function Route({
   actionData,
   params,
 }: Route.ComponentProps) {
+  const navigation = useNavigation()
+  const formBusy = navigation.state === 'submitting'
+
   if (loaderData.locked) {
     return (
       <LockedGateView
         enigmaName={loaderData.enigmaName}
         prompt={loaderData.prompt}
         actionData={actionData}
+        formBusy={formBusy}
       />
     )
   }
@@ -322,15 +342,20 @@ export default function Route({
                   name="lastAnswer"
                   type="text"
                   autoComplete="off"
+                  disabled={formBusy}
                   placeholder="Ex.: a palavra ou frase que você encontrou"
-                  className="w-full rounded-md border-1 p-2"
+                  className="w-full rounded-md border-1 p-2 disabled:cursor-not-allowed disabled:opacity-60"
                 />
                 {actionData?.error && (
                   <p className="text-sm text-red-600" role="alert">
                     {actionData.error}
                   </p>
                 )}
-                <Button type="submit" className="w-full py-3 text-base font-semibold">
+                <Button
+                  type="submit"
+                  disabled={formBusy}
+                  className="w-full py-3 text-base font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+                >
                   Ir para a fase
                 </Button>
               </Form>


### PR DESCRIPTION
Add per-IP+slug sliding window for answer submissions with safe map eviction (no full clear).

Load light enigma metadata plus full payload only for the active phase; use session role for entrance access without extra User reads.

Signed celebration cookie gates parabens and mais-por-vir; widen parabens type for light enigma shape.

Reject duplicate normalized answers in phase create/edit; error banner with scroll-to-view.

Play UI: inline wrong/429 messages, disable submit while pending; same pattern on entrada and admin phase/enigma forms.

Guest /enigmas: omit enigma list from loader JSON; decorative doors under login overlay.

Helpers: request IP, play query loaders, rate-limit module.
Made-with: Cursor