### PR TITLE
feat: página 404 personalizada com flamingo e destaque VOLTAR

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -383,3 +383,34 @@
   filter: drop-shadow(0 0 6px rgb(16 185 129 / 0.45));
 }
 
+@keyframes not-found-q-bob {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.82;
+  }
+  50% {
+    transform: translateY(-5px);
+    opacity: 1;
+  }
+}
+
+.not-found-q-mark {
+  display: inline-block;
+  animation: not-found-q-bob 1.35s ease-in-out infinite;
+}
+
+.not-found-q-mark--delay-1 {
+  animation-delay: 0.18s;
+}
+
+.not-found-q-mark--delay-2 {
+  animation-delay: 0.36s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .not-found-q-mark {
+    animation: none;
+  }
+}
+

--- a/app/components/enigmas-detective-flamingo/enigmas-detective-flamingo.component.tsx
+++ b/app/components/enigmas-detective-flamingo/enigmas-detective-flamingo.component.tsx
@@ -1,11 +1,17 @@
 /**
  * Flamingo colorido (SVG fornecido) + chapéu de detetive e lupa, para decoração da lista de enigmas.
+ * `plain`: só o flamingo, sem acessórios e sem inclinação (ex.: página 404).
  */
 export default function EnigmasDetectiveFlamingo({
   className = '',
+  variant = 'detective',
 }: {
   className?: string
+  variant?: 'detective' | 'plain'
 }) {
+  const bodyTransform =
+    variant === 'plain' ? undefined : 'rotate(26, 72, 524)'
+
   return (
     <div
       className={`pointer-events-none select-none ${className}`}
@@ -21,7 +27,7 @@ export default function EnigmasDetectiveFlamingo({
           Rotação em torno da base esquerda (pés): corpo em diagonal para a direita,
           como a olhar para as portas. Pivô ~ (72, 524) no viewBox.
         */}
-        <g transform="rotate(26, 72, 524)">
+        <g transform={bodyTransform}>
         {/* Flamingo (base) */}
         <g id="flamingo-art">
           <path
@@ -62,64 +68,68 @@ export default function EnigmasDetectiveFlamingo({
           />
           <circle cx="239.46" cy="38.96" r="8.16" fill="#5c6667" />
         </g>
-        {/* Chapéu centrado acima da cabeça (olho ~239,39) — translateY sobe o conjunto */}
-        <g id="detective-hat" transform="translate(0, -18)">
-          <ellipse
-            cx="239.5"
-            cy="24"
-            rx="58"
-            ry="11"
-            fill="#2d2118"
-            opacity={0.96}
-          />
-          <path
-            d="M188 27 Q239.5 -24 291 27 L281 41 Q239.5 54 198 41 Z"
-            fill="#3d2e24"
-          />
-          <ellipse
-            cx="239.5"
-            cy="31"
-            rx="30"
-            ry="7"
-            fill="#1a1410"
-            opacity={0.42}
-          />
-          <path
-            d="M214 23 L239.5 4 L265 23"
-            fill="none"
-            stroke="#5c4a3d"
-            strokeWidth={2.5}
-            strokeLinecap="round"
-          />
-        </g>
-        {/* Lupa à frente, apontando às portas */}
-        <g transform="translate(118, 122) rotate(30)">
-          <circle
-            cx={0}
-            cy={0}
-            r={26}
-            fill="rgba(186, 220, 255, 0.28)"
-            stroke="#4a5568"
-            strokeWidth={3.5}
-          />
-          <circle
-            cx={0}
-            cy={0}
-            r={22}
-            fill="none"
-            stroke="rgba(255,255,255,0.5)"
-            strokeWidth={1}
-          />
-          <line
-            x1={18}
-            y1={20}
-            x2={62}
-            y2={68}
-            stroke="#3d4852"
-            strokeWidth={7}
-            strokeLinecap="round"
-          />
-        </g>
+        {variant === 'detective' ? (
+          <>
+            {/* Chapéu centrado acima da cabeça (olho ~239,39) — translateY sobe o conjunto */}
+            <g id="detective-hat" transform="translate(0, -18)">
+              <ellipse
+                cx="239.5"
+                cy="24"
+                rx="58"
+                ry="11"
+                fill="#2d2118"
+                opacity={0.96}
+              />
+              <path
+                d="M188 27 Q239.5 -24 291 27 L281 41 Q239.5 54 198 41 Z"
+                fill="#3d2e24"
+              />
+              <ellipse
+                cx="239.5"
+                cy="31"
+                rx="30"
+                ry="7"
+                fill="#1a1410"
+                opacity={0.42}
+              />
+              <path
+                d="M214 23 L239.5 4 L265 23"
+                fill="none"
+                stroke="#5c4a3d"
+                strokeWidth={2.5}
+                strokeLinecap="round"
+              />
+            </g>
+            {/* Lupa à frente, apontando às portas */}
+            <g transform="translate(118, 122) rotate(30)">
+              <circle
+                cx={0}
+                cy={0}
+                r={26}
+                fill="rgba(186, 220, 255, 0.28)"
+                stroke="#4a5568"
+                strokeWidth={3.5}
+              />
+              <circle
+                cx={0}
+                cy={0}
+                r={22}
+                fill="none"
+                stroke="rgba(255,255,255,0.5)"
+                strokeWidth={1}
+              />
+              <line
+                x1={18}
+                y1={20}
+                x2={62}
+                y2={68}
+                stroke="#3d4852"
+                strokeWidth={7}
+                strokeLinecap="round"
+              />
+            </g>
+          </>
+        ) : null}
         </g>
       </svg>
     </div>

--- a/app/components/not-found-page/not-found-page.component.tsx
+++ b/app/components/not-found-page/not-found-page.component.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from 'react'
+import EnigmasDetectiveFlamingo from '~/components/enigmas-detective-flamingo/enigmas-detective-flamingo.component'
+import Link from '~/components/link/link.component'
+
+export default function NotFoundPage() {
+  useEffect(() => {
+    document.title = 'Página não encontrada | Mazeps'
+  }, [])
+
+  return (
+    <main className="min-h-[min(100dvh,900px)] w-full px-6 py-8 sm:px-10 sm:py-12">
+      <div className="mx-auto flex max-w-5xl flex-col gap-10 md:flex-row md:items-start md:justify-between md:gap-8">
+        <div className="max-w-xl shrink-0 text-left">
+          <h1 className="font-brand text-4xl font-semibold tracking-wide text-foreground sm:text-5xl">
+            ERRO 404
+          </h1>
+          <p className="mt-3 text-lg font-medium text-foreground/85 sm:text-xl">
+            Essa página não existe!
+          </p>
+          <div className="mt-5 min-w-0 w-full overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch]">
+            <p className="whitespace-nowrap text-base text-foreground/70 sm:text-[1.05rem]">
+              Você não estava tentando chutar os enigmas né?
+            </p>
+          </div>
+          <div className="mt-8 w-full max-w-sm rounded-2xl border-2 border-primary bg-primary/10 p-4 shadow-lg shadow-primary/25 ring-2 ring-primary/30 dark:bg-primary/[0.14] dark:ring-primary/40">
+            <Link
+              to="/"
+              className="flex w-full items-center justify-center rounded-xl bg-primary py-4 font-brand text-xl font-bold uppercase tracking-[0.2em] text-on-primary shadow-md transition sm:text-2xl hover:!no-underline hover:brightness-105 active:scale-[0.99] active:brightness-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            >
+              VOLTAR
+            </Link>
+          </div>
+        </div>
+
+        <div
+          className="relative mx-auto flex w-full max-w-[min(100%,340px)] shrink-0 justify-center md:mx-0 md:ml-auto md:max-w-[400px] md:justify-end"
+          aria-hidden
+        >
+          <div className="relative w-full">
+            <div className="pointer-events-none absolute -top-1 left-[62%] z-10 flex items-start gap-1 sm:left-[64%] sm:gap-1.5">
+              <span className="not-found-q-mark font-brand text-[4rem] font-bold leading-none text-primary/90 drop-shadow-sm sm:text-[4.75rem] md:text-[5.25rem]">
+                ?
+              </span>
+              <span className="not-found-q-mark not-found-q-mark--delay-1 mt-5 font-brand text-[3.25rem] font-bold leading-none text-primary/78 drop-shadow-sm sm:mt-6 sm:text-[3.85rem] md:text-[4.25rem]">
+                ?
+              </span>
+              <span className="not-found-q-mark not-found-q-mark--delay-2 mt-2 font-brand text-[2.85rem] font-bold leading-none text-primary/68 drop-shadow-sm sm:text-[3.35rem] md:text-[3.75rem]">
+                ?
+              </span>
+            </div>
+            <EnigmasDetectiveFlamingo
+              variant="plain"
+              className="w-full scale-x-[-1] opacity-[0.92] drop-shadow-lg"
+            />
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,6 +7,7 @@ import {
   ScrollRestoration,
 } from 'react-router'
 import type { Route } from './+types/root'
+import NotFoundPage from '~/components/not-found-page/not-found-page.component'
 import { useNonce } from './services/nonce'
 import './app.css'
 
@@ -74,16 +75,17 @@ export default function App() {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return <NotFoundPage />
+  }
+
   let message = 'Oops!'
   let details = 'An unexpected error occurred.'
   let stack: string | undefined
 
   if (isRouteErrorResponse(error)) {
-    message = error.status === 404 ? '404' : 'Error'
-    details =
-      error.status === 404
-        ? 'The requested page could not be found.'
-        : error.statusText || details
+    message = `Erro ${error.status}`
+    details = error.statusText || details
   } else if (import.meta.env.DEV && error && error instanceof Error) {
     details = error.message
     stack = error.stack


### PR DESCRIPTION
- Nova NotFoundPage (textos, flamingo plain espelhado, interrogações animadas)

- Variante plain no EnigmasDetectiveFlamingo (sem chapéu/lupa/inclinação)

- ErrorBoundary em root.tsx e estilos em app.css para a 404

- Caixa de destaque com link VOLTAR para o início

Made-with: Cursor