### PR TITLE
feat(profile): opt-in newsletter, exportação TXT e edição admin

### DIFF
--- a/app/components/profile-page/profile-page.component.tsx
+++ b/app/components/profile-page/profile-page.component.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
-import { Form } from 'react-router'
+import { useEffect, useState } from 'react'
+import { Form, Link as RouterLink, useFetcher, useRevalidator } from 'react-router'
 import { formatEventDate } from '~/lib/date'
 import type { ProfilePageData } from '~/lib/profile-page-data'
+import { Role } from '~/generated/prisma/enums'
 import BackButtonPortal from '~/components/back-button-portal/back-button-portal.component'
 import Button from '~/components/button/button.component'
 import Center from '~/components/center/center.component'
@@ -520,6 +521,8 @@ export function ProfilePage({
   loaderData: ProfilePageLoaderData
 }) {
   const [avatarError, setAvatarError] = useState(false)
+  const newsEmailsFetcher = useFetcher<{ ok?: boolean }>()
+  const revalidator = useRevalidator()
   const {
     currentUser,
     eventParticipants,
@@ -528,6 +531,15 @@ export function ProfilePage({
     adminPreview,
   } = loaderData
   const showAvatar = currentUser.avatarUrl && !avatarError
+
+  useEffect(() => {
+    if (
+      newsEmailsFetcher.state === 'idle' &&
+      newsEmailsFetcher.data?.ok === true
+    ) {
+      revalidator.revalidate()
+    }
+  }, [newsEmailsFetcher.state, newsEmailsFetcher.data, revalidator])
 
   return (
     <>
@@ -544,7 +556,7 @@ export function ProfilePage({
           )}
           {/* Header: avatar + nome + editar (sempre no topo) */}
           <div className="mb-8 flex flex-col gap-6 sm:flex-row sm:items-start lg:mb-10">
-            <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-start">
+            <div className="flex w-full min-w-0 flex-col items-center gap-4 sm:flex-row sm:items-start">
               {showAvatar ? (
                 <img
                   src={currentUser.avatarUrl}
@@ -558,25 +570,83 @@ export function ProfilePage({
                   {getInitials(currentUser.name)}
                 </div>
               )}
-              <div className="text-center sm:text-left">
-                <h1 className="text-2xl font-semibold tracking-tight">
-                  <SupporterNameDisplay
-                    name={currentUser.name}
-                    isSupporter={currentUser.isSupporter}
-                  />
-                </h1>
-                <p className="mt-1 text-foreground/60">
-                  <SupporterNameDisplay
-                    name={`@${currentUser.nickname}`}
-                    isSupporter={currentUser.isSupporter}
-                    nameClassName="text-foreground/60"
-                  />
-                </p>
-                <div className="mt-3 flex flex-wrap items-center justify-center gap-2 sm:justify-start">
-                  <span className="rounded-full bg-foreground/10 px-2.5 py-0.5 text-xs font-medium uppercase">
-                    {currentUser.role}
-                  </span>
+              <div className="flex w-full min-w-0 flex-1 flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+                <div className="min-w-0 text-center sm:flex-1 sm:text-left">
+                  <h1 className="text-2xl font-semibold tracking-tight">
+                    <SupporterNameDisplay
+                      name={currentUser.name}
+                      isSupporter={currentUser.isSupporter}
+                    />
+                  </h1>
+                  <p className="mt-1 text-foreground/60">
+                    <SupporterNameDisplay
+                      name={`@${currentUser.nickname}`}
+                      isSupporter={currentUser.isSupporter}
+                      nameClassName="text-foreground/60"
+                    />
+                  </p>
+                  <div className="mt-3 flex flex-wrap items-center justify-center gap-2 sm:justify-start">
+                    <span className="rounded-full bg-foreground/10 px-2.5 py-0.5 text-xs font-medium uppercase">
+                      {currentUser.role}
+                    </span>
+                  </div>
                 </div>
+                {!adminPreview && (
+                  <newsEmailsFetcher.Form
+                    method="post"
+                    action="/profile"
+                    className="relative w-full max-w-full shrink-0 overflow-hidden rounded-2xl border border-primary/30 bg-gradient-to-br from-primary/[0.14] via-accent/[0.1] to-primary/[0.05] px-4 py-3.5 shadow-[0_12px_36px_-14px_color-mix(in_oklab,var(--color-primary)_45%,transparent)] ring-1 ring-inset ring-primary/20 backdrop-blur-[2px] sm:max-w-[min(100%,17.5rem)]"
+                  >
+                    <div
+                      className="pointer-events-none absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-primary via-accent to-primary/50"
+                      aria-hidden
+                    />
+                    <input
+                      type="hidden"
+                      name="_action"
+                      value="updateNewsEmails"
+                    />
+                    <label className="relative flex cursor-pointer items-start gap-3 pl-1.5 text-left text-sm leading-snug">
+                      <span
+                        className="mt-0.5 shrink-0 [&_svg]:!text-primary [&_svg]:stroke-[2.25]"
+                        aria-hidden
+                      >
+                        <MailIcon />
+                      </span>
+                      <span className="flex min-w-0 flex-1 items-start gap-3">
+                        <span className="relative mt-1 inline-flex h-4 w-4 shrink-0">
+                          <input
+                            type="checkbox"
+                            name="newsletterSubscribed"
+                            defaultChecked={currentUser.newsletterSubscribed}
+                            key={String(currentUser.newsletterSubscribed)}
+                            disabled={newsEmailsFetcher.state !== 'idle'}
+                            onChange={(e) => {
+                              const form = e.currentTarget.form
+                              if (form) newsEmailsFetcher.submit(form)
+                            }}
+                            className="peer h-4 w-4 cursor-pointer appearance-none rounded border-2 border-primary/55 bg-primary/15 shadow-[inset_0_1px_2px_rgba(0,0,0,0.12)] transition-colors checked:border-primary checked:bg-primary hover:border-primary/70 hover:bg-primary/25 checked:hover:bg-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/50 disabled:cursor-not-allowed disabled:opacity-50 dark:shadow-[inset_0_1px_2px_rgba(0,0,0,0.35)]"
+                          />
+                          <svg
+                            className="pointer-events-none absolute left-0.5 top-0.5 h-3 w-3 text-on-primary opacity-0 transition-opacity peer-checked:opacity-100"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="3.2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            aria-hidden
+                          >
+                            <path d="M5 13l4 4L19 7" />
+                          </svg>
+                        </span>
+                        <span className="min-w-0 font-medium text-foreground/95 [text-wrap:balance]">
+                          Desejo receber e-mails com novidades
+                        </span>
+                      </span>
+                    </label>
+                  </newsEmailsFetcher.Form>
+                )}
               </div>
             </div>
             {!adminPreview && (
@@ -811,10 +881,24 @@ export function ProfilePage({
             </section>
           </div>
 
-          {/* Sair — centralizado por último */}
+          {/* Admin: exportar e-mails da newsletter — Sair */}
           {!adminPreview && (
-            <div className="mx-auto flex w-full max-w-sm justify-center px-2 pb-2">
-              <Form method="post" action="/logout" className="w-full sm:w-auto">
+            <div className="mx-auto flex w-full max-w-sm flex-col items-stretch gap-3 px-2 pb-2">
+              {currentUser.role === Role.ADMIN && (
+                <RouterLink
+                  to="/profile/newsletter-emails"
+                  reloadDocument
+                  className="bg-secondary text-on-secondary border-on-secondary flex w-full min-w-[12rem] items-center justify-center gap-2 rounded-md border p-2 text-center transition-transform hover:scale-[1.02] active:scale-[0.98] motion-reduce:transform-none sm:w-auto sm:self-center [&_svg]:!text-on-secondary"
+                >
+                  <MailIcon />
+                  Receber e-mails válidos:
+                </RouterLink>
+              )}
+              <Form
+                method="post"
+                action="/logout"
+                className="flex w-full justify-center sm:w-auto sm:self-center"
+              >
                 <Button
                   type="submit"
                   className="flex w-full min-w-[12rem] items-center justify-center gap-2 sm:w-auto"

--- a/app/lib/profile-page-data.ts
+++ b/app/lib/profile-page-data.ts
@@ -22,6 +22,7 @@ export async function loadProfilePageData(
         favoriteGame: true,
         favoriteEvent: true,
         isSupporter: true,
+        newsletterSubscribed: true,
       },
     }),
     prisma.eventParticipant.findMany({

--- a/app/routes/profile/route.tsx
+++ b/app/routes/profile/route.tsx
@@ -1,4 +1,4 @@
-import { redirect } from 'react-router'
+import { data, redirect } from 'react-router'
 import type { Route } from './+types/route'
 import { ProfilePage } from '~/components/profile-page/profile-page.component'
 import { loadProfilePageData } from '~/lib/profile-page-data'
@@ -6,13 +6,32 @@ import { loadProfilePageData } from '~/lib/profile-page-data'
 export async function loader({ context }: Route.LoaderArgs) {
   if (!context.currentUser) return redirect('/login')
 
-  const data = await loadProfilePageData(
+  const profileData = await loadProfilePageData(
     context.prisma,
     context.currentUser.id,
   )
-  if (!data) return redirect('/login')
+  if (!profileData) return redirect('/login')
 
-  return data
+  return profileData
+}
+
+export async function action({ request, context }: Route.ActionArgs) {
+  if (!context.currentUser) return redirect('/login')
+
+  const formData = await request.formData()
+  if (formData.get('_action') !== 'updateNewsEmails') {
+    return data({ error: 'Ação inválida' }, { status: 400 })
+  }
+
+  const newsletterSubscribed = formData.get('newsletterSubscribed') === 'on'
+
+  // Só o utilizador da sessão altera o próprio registo (não há userId no form).
+  await context.prisma.user.update({
+    where: { id: context.currentUser.id },
+    data: { newsletterSubscribed },
+  })
+
+  return { ok: true as const }
 }
 
 export default function Route({ loaderData }: Route.ComponentProps) {

--- a/app/routes/profile_.newsletter-emails/route.tsx
+++ b/app/routes/profile_.newsletter-emails/route.tsx
@@ -1,0 +1,25 @@
+import { redirect } from 'react-router'
+import type { Route } from './+types/route'
+import { Role } from '~/generated/prisma/enums'
+
+export async function loader({ context }: Route.LoaderArgs) {
+  if (!context.currentUser) return redirect('/login')
+  if (context.currentUser.role !== Role.ADMIN) {
+    throw new Response('Forbidden', { status: 403 })
+  }
+
+  const users = await context.prisma.user.findMany({
+    where: { newsletterSubscribed: true },
+    select: { email: true },
+    orderBy: { email: 'asc' },
+  })
+
+  const body = users.map((u) => u.email).join('\n')
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="emails-newsletter.txt"',
+    },
+  })
+}

--- a/app/routes/users_.$userId_.edit/route.tsx
+++ b/app/routes/users_.$userId_.edit/route.tsx
@@ -181,6 +181,26 @@ export default function Route({ loaderData }: Route.ComponentProps) {
               </section>
             )}
 
+            {isAdmin && (
+              <section className="rounded-2xl border border-foreground/10 bg-background/60 p-6 shadow-sm">
+                <h2 className="mb-4 text-xs font-semibold uppercase tracking-[0.2em] text-foreground/60">
+                  E-mail com novidades
+                </h2>
+                <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-foreground/10 px-4 py-3 transition-colors hover:bg-foreground/5">
+                  <input
+                    type="checkbox"
+                    name="newsletterSubscribed"
+                    value="on"
+                    defaultChecked={user.newsletterSubscribed}
+                    className="h-4 w-4 rounded border-foreground/30"
+                  />
+                  <span className="text-sm">
+                    Deseja receber e-mails com novidades
+                  </span>
+                </label>
+              </section>
+            )}
+
             {/* Excluir usuário (apenas ADMIN, não pode excluir a si mesmo) */}
             {canDeleteUser && (
               <section className="rounded-2xl border border-red-200 bg-red-50/50 p-6 shadow-sm dark:border-red-900/50 dark:bg-red-950/20">
@@ -334,16 +354,19 @@ export async function action({ context, request, params }: Route.ActionArgs) {
     return redirect('/users')
   }
 
+  const actorIsAdmin = context.currentUser.role === Role.ADMIN
+
   const user = await context.prisma.user.update({
     where: { id: Number(params.userId) },
     data: {
       name: formData.get('name') as string,
       email: formData.get('email') as string,
       nickname: formData.get('nickname') as string,
-      ...(context.currentUser.role === Role.ADMIN && {
+      ...(actorIsAdmin && {
         role: formData.get('role') as Role,
         isWriter: formData.get('isWriter') === 'on',
         isSupporter: formData.get('isSupporter') === 'on',
+        newsletterSubscribed: formData.get('newsletterSubscribed') === 'on',
       }),
     },
   })

--- a/prisma/migrations/20260415120000_add_user_newsletter_fields/migration.sql
+++ b/prisma/migrations/20260415120000_add_user_newsletter_fields/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "newsletterSubscribed" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "newsletterUnsubscribeToken" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_newsletterUnsubscribeToken_key" ON "User"("newsletterUnsubscribeToken");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,9 @@ model User {
   birthday DateTime?
   favoriteGame String?
   favoriteEvent String?
+  /// Opt-in para e-mails com novidades (marketing / newsletter)
+  newsletterSubscribed Boolean @default(false)
+  newsletterUnsubscribeToken String? @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   tournamentPlayers TournamentPlayer[]


### PR DESCRIPTION
- Campo newsletterSubscribed no User (migração) e carregamento no perfil.

- Perfil: caixa estilizada para receber e-mails; action POST só para o próprio utilizador.

- Editar utilizador (admin): secção E-mail com novidades.

- Admin no perfil: link resource route para descarregar emails-newsletter.txt (um e-mail por linha).

- Corrige conflito de imports Link (RouterLink) no profile-page.

Made-with: Cursor