### PR TITLE
feat(enigmas): convite WhatsApp com cores da skin e layout mobile

### DIFF
--- a/app/routes/enigmas/route.tsx
+++ b/app/routes/enigmas/route.tsx
@@ -70,6 +70,43 @@ export async function loader({ context }: Route.LoaderArgs) {
   }
 }
 
+const ENIGMAS_WHATSAPP_GROUP_URL =
+  'https://chat.whatsapp.com/Gybjbjr4RvZEqvh7HO78ec'
+
+function WhatsAppGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.435 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z" />
+    </svg>
+  )
+}
+
+/** Mobile: bloco no fim da página, centrado. Desktop (sm+): fixo no canto inferior direito. */
+function EnigmasWhatsAppFloatingInvite() {
+  return (
+    <a
+      href={ENIGMAS_WHATSAPP_GROUP_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="relative z-[60] mx-auto mt-10 flex w-full max-w-md flex-row items-center gap-3 rounded-2xl border border-foreground/15 bg-background/95 p-2.5 shadow-xl backdrop-blur-md transition-transform active:scale-[0.99] sm:fixed sm:bottom-6 sm:right-6 sm:mt-0 sm:w-auto sm:max-w-[min(calc(100vw-3rem),17rem)] sm:flex-col sm:items-end sm:gap-2 sm:rounded-none sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none sm:backdrop-blur-none sm:active:scale-100"
+      aria-label="Entre no nosso grupo de dicas no WhatsApp (abre numa nova aba)"
+    >
+      <span className="order-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary text-on-primary shadow-md ring-2 ring-on-primary/30 sm:order-2 sm:h-14 sm:w-14 sm:shadow-lg sm:ring-on-primary/35 sm:transition-transform sm:hover:scale-105 sm:active:scale-95">
+        <WhatsAppGlyph className="h-7 w-7 sm:h-8 sm:w-8" />
+      </span>
+      <span className="order-2 min-w-0 flex-1 text-center text-[0.8125rem] font-medium leading-snug text-foreground sm:order-1 sm:w-full sm:rounded-xl sm:border sm:border-foreground/15 sm:bg-background/95 sm:px-3 sm:py-2 sm:text-right sm:text-xs sm:shadow-lg sm:backdrop-blur-md md:text-sm">
+        Entre no nosso grupo de dicas!
+      </span>
+    </a>
+  )
+}
+
 function DoorIcon({ size = 'lg' }: { size?: 'lg' | 'sm' }) {
   const dim =
     size === 'sm' ? 'h-9 w-9 text-foreground/45' : 'h-16 w-16 text-foreground/40'
@@ -173,6 +210,8 @@ function EmBrevePage() {
           <p className="mt-2 text-center font-mono text-xs tracking-[0.3em] text-foreground/30">
             Em breve, novos desafios serão revelados
           </p>
+
+          <EnigmasWhatsAppFloatingInvite />
         </div>
         </Center>
       </div>
@@ -425,6 +464,8 @@ export default function Route({ loaderData }: Route.ComponentProps) {
           {isAdmin && loaderData.enigmas.length > 0 && (
             <AdminEnigmaManageList enigmas={loaderData.enigmas} />
           )}
+
+          <EnigmasWhatsAppFloatingInvite />
         </div>
         </Center>
       </div>


### PR DESCRIPTION
- Link do grupo de dicas; ícone e texto com primary/on-primary.

- Mobile: bloco no fim da página centrado; desktop: fixo no canto.

- z-index acima do overlay de visitante; padding extra removido.

Made-with: Cursor