### PR TITLE
feat(enigmas): certificados, textos finais, listagem e correções de j…

### DIFF
--- a/app/components/calendar/calendar.component.tsx
+++ b/app/components/calendar/calendar.component.tsx
@@ -8,7 +8,6 @@ const DAYS_PT = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb']
 // Format: 'YYYY-MM-DD' => event label
 const EVENTS: Record<string, string> = {
   '2026-03-21': 'CMBG TACTICS',
-  '2026-04-24': 'Início Youtube',
   '2026-04-17': 'Enigmas?',
 }
 

--- a/app/components/enigma-card-symbol/enigma-card-symbol-form-field.component.tsx
+++ b/app/components/enigma-card-symbol/enigma-card-symbol-form-field.component.tsx
@@ -12,7 +12,7 @@ export function EnigmaCardSymbolFormField({
   helperText,
 }: {
   defaultSymbol: EnigmaCardSymbol
-  helperText: ReactNode
+  helperText?: ReactNode
 }) {
   return (
     <fieldset
@@ -22,8 +22,12 @@ export function EnigmaCardSymbolFormField({
       <legend className="px-1 font-brand text-sm font-semibold uppercase tracking-[0.12em] text-foreground/70 sm:text-base">
         Símbolo do cartão
       </legend>
-      <p className="mb-4 mt-2 text-sm text-foreground/55">{helperText}</p>
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-5">
+      {helperText ? (
+        <p className="mb-4 mt-2 text-sm text-foreground/55">{helperText}</p>
+      ) : null}
+      <div
+        className={`grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-5${helperText ? '' : ' mt-2'}`}
+      >
         {ENIGMA_CARD_SYMBOL_OPTIONS.map((opt) => (
           <label
             key={opt.value}

--- a/app/components/enigma-journey-interlude/enigma-journey-interlude.component.tsx
+++ b/app/components/enigma-journey-interlude/enigma-journey-interlude.component.tsx
@@ -5,8 +5,11 @@ import Spacer from '~/components/spacer/spacer.component'
 
 export default function EnigmaJourneyInterlude({
   enigmaName,
+  customBody,
 }: {
   enigmaName: string
+  /** Se definido, substitui os dois parágrafos narrativos abaixo do título principal (várias linhas). */
+  customBody?: string | null
 }) {
   return (
     <>
@@ -28,34 +31,38 @@ export default function EnigmaJourneyInterlude({
         `}</style>
         <Center>
           <div className="relative z-10 mx-auto max-w-lg px-6 text-center">
-            <p
-              className="font-mono text-xs uppercase tracking-[0.45em] text-foreground/40"
+            <h1
+              className="text-balance font-brand text-2xl font-semibold tracking-wide text-foreground/90 sm:text-3xl md:text-4xl"
               style={{ animation: 'enigma-fade 0.9s ease-out both' }}
             >
-              …
-            </p>
-            <Spacer size="md" />
-            <h1
-              className="font-brand text-3xl font-semibold tracking-wide text-foreground/90 sm:text-4xl"
-              style={{ animation: 'enigma-fade 0.9s ease-out 0.15s both' }}
-            >
-              Chegaste até aqui
+              Você chegou até aqui, mas este não é o fim...
             </h1>
             <Spacer size="md" />
-            <p
-              className="text-lg leading-relaxed text-foreground/70"
-              style={{ animation: 'enigma-fade 0.9s ease-out 0.3s both' }}
-            >
-              Algo em ti desvendou o trecho que estava ao alcance de todos em{' '}
-              <strong className="font-medium text-foreground/85">{enigmaName}</strong>.
-            </p>
-            <Spacer size="sm" />
-            <p
-              className="text-base leading-relaxed text-foreground/55"
-              style={{ animation: 'enigma-fade 0.9s ease-out 0.45s both' }}
-            >
-              Ainda há caminhos por abrir. Esta jornada não terminou — volta mais tarde.
-            </p>
+            {customBody?.trim() ? (
+              <p
+                className="whitespace-pre-line text-lg leading-relaxed text-foreground/70"
+                style={{ animation: 'enigma-fade 0.9s ease-out 0.3s both' }}
+              >
+                {customBody.trim()}
+              </p>
+            ) : (
+              <>
+                <p
+                  className="text-lg leading-relaxed text-foreground/70"
+                  style={{ animation: 'enigma-fade 0.9s ease-out 0.3s both' }}
+                >
+                  Algo em ti desvendou o trecho que estava ao alcance de todos em{' '}
+                  <strong className="font-medium text-foreground/85">{enigmaName}</strong>.
+                </p>
+                <Spacer size="sm" />
+                <p
+                  className="text-base leading-relaxed text-foreground/55"
+                  style={{ animation: 'enigma-fade 0.9s ease-out 0.45s both' }}
+                >
+                  Ainda há caminhos por abrir. Esta jornada não terminou — volta mais tarde.
+                </p>
+              </>
+            )}
             <Spacer size="lg" />
             <Link
               to="/enigmas"

--- a/app/components/enigma-phase-form/enigma-phase-form.component.tsx
+++ b/app/components/enigma-phase-form/enigma-phase-form.component.tsx
@@ -41,6 +41,9 @@ interface EnigmaPhaseFormProps {
     extraTipPhrases?: unknown
     extraHiddenHints?: unknown
     whiteScreenHints?: unknown
+    providesCertificate?: boolean
+    certificateTitle?: string | null
+    certificateImageUrl?: string | null
   }
   submitLabel: string
   /** Na edição: resposta num bloco destacado no fim (acima do envio / zona de perigo). */
@@ -193,6 +196,10 @@ export default function EnigmaPhaseForm({
         popupText: h.popupText,
       }),
     ),
+  )
+
+  const [certificateEnabled, setCertificateEnabled] = useState(
+    Boolean(defaultValues?.providesCertificate),
   )
 
   const supportsUpload = mediaType === 'IMAGE' || mediaType === 'AUDIO'
@@ -722,6 +729,72 @@ export default function EnigmaPhaseForm({
             />
           </div>
         ))}
+      </div>
+
+      <Spacer size="md" />
+      <div className="rounded-2xl border-2 border-primary/45 bg-primary/[0.08] p-6 shadow-md ring-1 ring-primary/15 sm:p-7 dark:border-primary/50 dark:bg-primary/15 dark:ring-primary/25">
+        <h2 className="font-brand mb-2 text-lg tracking-wide text-primary sm:text-xl">
+          Certificado (opcional)
+        </h2>
+        <p className="mb-5 text-sm text-foreground/65">
+          Esta fase fornece certificado? (quando concluída pela primeira vez por um jogador com sessão
+          iniciada, o certificado aparece no perfil dele.)
+        </p>
+        <label className="mb-5 flex cursor-pointer items-start gap-3.5 rounded-xl border border-primary/25 bg-background/50 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-4 dark:border-primary/35 dark:bg-background/30">
+          <input
+            type="checkbox"
+            name="providesCertificate"
+            value="yes"
+            checked={certificateEnabled}
+            onChange={(e) => setCertificateEnabled(e.target.checked)}
+            className="accent-primary mt-0.5 h-5 w-5 shrink-0 rounded border-primary/40 text-primary"
+          />
+          <span className="text-sm font-medium leading-snug text-foreground sm:text-base">
+            Sim — esta fase fornece certificado na primeira conclusão
+          </span>
+        </label>
+        {certificateEnabled ? (
+          <div className="space-y-4 border-t border-primary/20 pt-5">
+            <TextInput
+              id="certificateTitle"
+              name="certificateTitle"
+              label="Nome do certificado"
+              type="text"
+              required={certificateEnabled}
+              defaultValue={defaultValues?.certificateTitle ?? ''}
+              inputClassName="border-2 border-primary/30 bg-background"
+            />
+            <div>
+              <label
+                htmlFor="certificateImageFile"
+                className="mb-1 block text-sm font-medium text-foreground/85"
+              >
+                Imagem do certificado (JPEG)
+              </label>
+              <input
+                id="certificateImageFile"
+                name="certificateImageFile"
+                type="file"
+                accept="image/jpeg,.jpg,.jpeg"
+                className="block w-full max-w-lg text-sm file:mr-3 file:rounded-md file:border-2 file:border-primary/35 file:bg-primary/[0.12] file:px-3 file:py-2 file:text-sm file:font-medium file:text-foreground hover:file:bg-primary/[0.18] dark:file:bg-primary/20 dark:hover:file:bg-primary/25"
+              />
+              {defaultValues?.certificateImageUrl ? (
+                <p className="mt-2 text-xs text-foreground/55">
+                  Ficheiro atual:{' '}
+                  <a
+                    href={defaultValues.certificateImageUrl}
+                    className="text-primary underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    ver / descarregar
+                  </a>
+                  . Envie outro JPEG para substituir.
+                </p>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
       </div>
 
       {prominentAnswerSection ? (

--- a/app/components/enigma-phase-play/enigma-phase-play.component.tsx
+++ b/app/components/enigma-phase-play/enigma-phase-play.component.tsx
@@ -6,7 +6,11 @@ import type { ExtraMediaBlock } from '~/lib/enigma-phase-extras'
 import { MediaType } from '~/generated/prisma/enums'
 
 export type EnigmaPhasePlayLoaderData = {
-  enigma: { name: string }
+  enigma: {
+    name: string
+    parabensScreenBody: string | null
+    interludeScreenBody: string | null
+  }
   phase: {
     id: number
     title: string
@@ -128,9 +132,19 @@ export default function EnigmaPhasePlay({
 
   if (loaderData.isFinished) {
     if (loaderData.celebrationKind === 'interlude') {
-      return <EnigmaJourneyInterlude enigmaName={loaderData.enigma.name} />
+      return (
+        <EnigmaJourneyInterlude
+          enigmaName={loaderData.enigma.name}
+          customBody={loaderData.enigma.interludeScreenBody}
+        />
+      )
     }
-    return <ParabensCelebration enigmaName={loaderData.enigma.name} />
+    return (
+      <ParabensCelebration
+        enigmaName={loaderData.enigma.name}
+        customBody={loaderData.enigma.parabensScreenBody}
+      />
+    )
   }
 
   const { phase } = loaderData

--- a/app/components/parabens-celebration/parabens-celebration.component.tsx
+++ b/app/components/parabens-celebration/parabens-celebration.component.tsx
@@ -42,8 +42,11 @@ function Balloon({ delay, left, color }: { delay: number; left: number; color: s
 
 export default function ParabensCelebration({
   enigmaName,
+  customBody,
 }: {
   enigmaName: string
+  /** Se definido, substitui o parágrafo padrão abaixo do título (várias linhas). */
+  customBody?: string | null
 }) {
   const hasFired = useRef(false)
   const [showAnimations, setShowAnimations] = useState<boolean | null>(null)
@@ -134,14 +137,20 @@ export default function ParabensCelebration({
           </div>
           <Spacer size="lg" />
           <p
-            className="animate-[fade-in_0.6s_ease-out_0.2s_both] text-lg text-foreground/80 sm:text-xl"
+            className="animate-[fade-in_0.6s_ease-out_0.2s_both] whitespace-pre-line text-lg text-foreground/80 sm:text-xl"
             style={{ animationFillMode: 'both' }}
           >
-            Você completou o enigma{' '}
-            <strong className="font-semibold text-foreground/95">
-              {enigmaName}
-            </strong>
-            !
+            {customBody?.trim() ? (
+              customBody.trim()
+            ) : (
+              <>
+                Você completou o enigma{' '}
+                <strong className="font-semibold text-foreground/95">
+                  {enigmaName}
+                </strong>
+                !
+              </>
+            )}
           </p>
           <Spacer size="lg" />
           <Link

--- a/app/components/profile-page/profile-page.component.tsx
+++ b/app/components/profile-page/profile-page.component.tsx
@@ -75,6 +75,17 @@ function EventIcon() {
   )
 }
 
+function CertificateIcon() {
+  return (
+    <svg className={ICON_CLASS} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+      <polyline points="14 2 14 8 20 8" />
+      <path d="M12 18v-6" />
+      <path d="M9 15h6" />
+    </svg>
+  )
+}
+
 function PencilIcon() {
   return (
     <svg className="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -99,6 +110,25 @@ function ChevronRightIcon() {
       <path d="m9 18 6-6-6-6" />
     </svg>
   )
+}
+
+function DownloadIcon() {
+  return (
+    <svg className="h-4 w-4 shrink-0 text-foreground/50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" x2="12" y1="15" y2="3" />
+    </svg>
+  )
+}
+
+function certificateDownloadFilename(title: string) {
+  const base = title
+    .replace(/[/\\?%*:|"<>]/g, '-')
+    .trim()
+    .slice(0, 120)
+  const withExt = base.toLowerCase().endsWith('.jpg') ? base : `${base || 'certificado'}.jpg`
+  return withExt
 }
 
 function TrophyIcon() {
@@ -528,6 +558,7 @@ export function ProfilePage({
     eventParticipants,
     championTrophies,
     tournamentTrophies,
+    certificates,
     adminPreview,
   } = loaderData
   const showAvatar = currentUser.avatarUrl && !avatarError
@@ -668,7 +699,7 @@ export function ProfilePage({
             )}
           </div>
 
-          {/* Mobile: Informações → Troféus → Participações. lg: col1 L1/L2 = Info + Participações; col2 = troféus row-span-2 */}
+          {/* Mobile: Informações → Troféus → Participações → Certificados. lg: col1 = Info + Participações + Certificados; col2 = troféus row-span-3 */}
           <div className="mb-8 flex flex-col gap-8 lg:mb-10 lg:grid lg:grid-cols-2 lg:items-start lg:gap-10">
             {/* Informações — lg: col1 L1 (Participações fica L2 na mesma coluna; troféus ocupam a direita em 2 linhas) */}
             <section className="min-w-0 rounded-2xl border border-foreground/10 bg-background/60 p-6 shadow-sm lg:col-start-1 lg:row-start-1 lg:self-start">
@@ -730,8 +761,8 @@ export function ProfilePage({
               </div>
             </section>
 
-            {/* Prateleira — lg: col2 com row-span-2 para não esticar só a linha 1 e atrasar Participações */}
-            <section className="min-w-0 rounded-2xl border border-foreground/10 bg-background/60 p-6 shadow-sm lg:col-start-2 lg:row-span-2 lg:row-start-1 lg:min-h-0 lg:self-start">
+            {/* Prateleira — lg: col2 com row-span-3 para cobrir Informações + Participações + Certificados */}
+            <section className="min-w-0 rounded-2xl border border-foreground/10 bg-background/60 p-6 shadow-sm lg:col-start-2 lg:row-span-3 lg:row-start-1 lg:min-h-0 lg:self-start">
               <h2 className="mb-4 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-foreground/60">
                 <TrophyIcon />
                 Prateleira de Troféus
@@ -879,6 +910,41 @@ export function ProfilePage({
                           </div>
                           <ChevronRightIcon />
                         </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </section>
+
+            {/* Certificados — enigmas: primeira conclusão de fase com certificado (utilizador autenticado) */}
+            <section className="min-w-0 overflow-hidden rounded-2xl border border-foreground/10 bg-background/60 shadow-sm lg:col-start-1 lg:row-start-3 lg:self-start">
+              <div className="flex items-center gap-2 border-b border-foreground/10 bg-foreground/5 px-6 py-4">
+                <CertificateIcon />
+                <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-foreground/60">
+                  Certificados ({certificates.length})
+                </h2>
+              </div>
+              <div>
+                {certificates.length === 0 ? (
+                  <p className="px-6 py-8 text-center text-sm text-foreground/50">
+                    Nenhum certificado ainda.
+                  </p>
+                ) : (
+                  <ul className="divide-y divide-foreground/10">
+                    {certificates.map((c) => (
+                      <li key={c.id}>
+                        <div className="flex items-center gap-3 px-6 py-4">
+                          <p className="min-w-0 flex-1 font-medium">{c.title}</p>
+                          <a
+                            href={c.imageUrl}
+                            download={certificateDownloadFilename(c.title)}
+                            className="text-foreground/60 hover:text-foreground flex shrink-0 items-center gap-1.5 rounded-lg p-2 transition-colors hover:bg-foreground/5"
+                            aria-label={`Descarregar certificado: ${c.title}`}
+                          >
+                            <DownloadIcon />
+                          </a>
+                        </div>
                       </li>
                     ))}
                   </ul>

--- a/app/lib/enigma-phase-certificate-award.server.ts
+++ b/app/lib/enigma-phase-certificate-award.server.ts
@@ -1,0 +1,46 @@
+import type { PrismaClient } from '~/generated/prisma/client'
+import { PrismaClientKnownRequestError } from '~/generated/prisma/internal/prismaNamespace'
+import type { CurrentUser } from '~/services/session'
+
+type PhaseCertFields = {
+  id: number
+  providesCertificate: boolean
+  certificateTitle: string | null
+  certificateImageUrl: string | null
+}
+
+/**
+ * Na primeira resposta certa, com sessão e fase configurada com certificado + JPEG.
+ * Usado tanto em `/enigmas/:slug` (primeira fase) como em `/enigmas/:slug/:phaseKey`.
+ */
+export async function grantEnigmaPhaseCertificateIfEligible(
+  prisma: PrismaClient,
+  currentUser: CurrentUser | undefined,
+  phaseFull: PhaseCertFields,
+): Promise<void> {
+  const certTitle = phaseFull.certificateTitle?.trim()
+  const certUrl = phaseFull.certificateImageUrl?.trim()
+  if (
+    !currentUser ||
+    phaseFull.providesCertificate !== true ||
+    !certTitle ||
+    !certUrl
+  ) {
+    return
+  }
+  try {
+    await prisma.enigmaPhaseCertificateAward.create({
+      data: {
+        userId: currentUser.id,
+        enigmaPhaseId: phaseFull.id,
+        awardTitle: certTitle,
+        awardImageUrl: certUrl,
+      },
+    })
+  } catch (e) {
+    if (e instanceof PrismaClientKnownRequestError && e.code === 'P2002') {
+      return
+    }
+    throw e
+  }
+}

--- a/app/lib/enigma-phase-certificate.server.ts
+++ b/app/lib/enigma-phase-certificate.server.ts
@@ -1,0 +1,60 @@
+import { saveEnigmaCertificateJpeg } from '~/lib/upload'
+
+export type ResolvedPhaseCertificate = {
+  providesCertificate: boolean
+  certificateTitle: string | null
+  certificateImageUrl: string | null
+}
+
+export async function resolvePhaseCertificateFromForm(
+  formData: FormData,
+  existing: ResolvedPhaseCertificate,
+): Promise<
+  ({ ok: true } & ResolvedPhaseCertificate) | { ok: false; error: string }
+> {
+  const providesCertificate = formData.get('providesCertificate') === 'yes'
+  const titleRaw = String(formData.get('certificateTitle') ?? '').trim()
+  const file = formData.get('certificateImageFile')
+
+  if (!providesCertificate) {
+    return {
+      ok: true,
+      providesCertificate: false,
+      certificateTitle: null,
+      certificateImageUrl: null,
+    }
+  }
+
+  if (!titleRaw) {
+    return {
+      ok: false,
+      error:
+        'Com certificado ativo, indique o nome do certificado (texto mostrado no perfil).',
+    }
+  }
+
+  let certificateImageUrl = existing.certificateImageUrl
+  if (file instanceof File && file.size > 0) {
+    try {
+      certificateImageUrl = await saveEnigmaCertificateJpeg(file, titleRaw)
+    } catch (e) {
+      const msg =
+        e instanceof Error ? e.message : 'Falha ao enviar a imagem do certificado.'
+      return { ok: false, error: msg }
+    }
+  }
+
+  if (!certificateImageUrl) {
+    return {
+      ok: false,
+      error: 'Envie uma imagem JPEG para o certificado.',
+    }
+  }
+
+  return {
+    ok: true,
+    providesCertificate: true,
+    certificateTitle: titleRaw,
+    certificateImageUrl,
+  }
+}

--- a/app/lib/enigma-play-public.ts
+++ b/app/lib/enigma-play-public.ts
@@ -17,6 +17,9 @@ export function toPublicEnigmaPhase<
     extraTipPhrases?: unknown
     extraHiddenHints?: unknown
     whiteScreenHints?: unknown
+    providesCertificate?: boolean
+    certificateTitle?: string | null
+    certificateImageUrl?: string | null
   },
 >(phase: T) {
   const {
@@ -27,6 +30,9 @@ export function toPublicEnigmaPhase<
     extraTipPhrases,
     extraHiddenHints,
     whiteScreenHints: _whiteScreenHints,
+    providesCertificate: _providesCertificate,
+    certificateTitle: _certificateTitle,
+    certificateImageUrl: _certificateImageUrl,
     ...rest
   } = phase
   const hint = hiddenHint?.trim()
@@ -44,6 +50,16 @@ export function toPublicEnigmaPhase<
 }
 
 /** Só o necessário para a tela de jogar / parabéns (evita vazar `phases[].answer`). */
-export function toPublicEnigmaPlay(enigma: { name: string }) {
-  return { name: enigma.name }
+export function toPublicEnigmaPlay(enigma: {
+  name: string
+  parabensScreenBody?: string | null
+  interludeScreenBody?: string | null
+}) {
+  const parabens = enigma.parabensScreenBody?.trim()
+  const interlude = enigma.interludeScreenBody?.trim()
+  return {
+    name: enigma.name,
+    parabensScreenBody: parabens ? parabens : null,
+    interludeScreenBody: interlude ? interlude : null,
+  }
 }

--- a/app/lib/enigma-play-queries.server.ts
+++ b/app/lib/enigma-play-queries.server.ts
@@ -16,6 +16,8 @@ export async function loadEnigmaLightForPlay(
       publicPhaseOrderTo: true,
       entrancePasswordHash: true,
       entrancePasswordPrompt: true,
+      parabensScreenBody: true,
+      interludeScreenBody: true,
       phases: {
         orderBy: { order: 'asc' },
         select: {
@@ -47,6 +49,9 @@ const phasePlayPayloadSelect = {
   extraHiddenHints: true,
   whiteScreenHints: true,
   answer: true,
+  providesCertificate: true,
+  certificateTitle: true,
+  certificateImageUrl: true,
 } as const
 
 export type EnigmaPhasePlayPayload = NonNullable<

--- a/app/lib/profile-page-data.ts
+++ b/app/lib/profile-page-data.ts
@@ -6,7 +6,7 @@ export async function loadProfilePageData(
   prisma: PrismaClient,
   userId: number,
 ) {
-  const [user, eventParticipants] = await Promise.all([
+  const [user, eventParticipants, certificateAwards] = await Promise.all([
     prisma.user.findUnique({
       where: { id: userId },
       select: {
@@ -39,6 +39,21 @@ export async function loadProfilePageData(
         },
       },
       orderBy: { checkedInAt: 'desc' },
+    }),
+    prisma.enigmaPhaseCertificateAward.findMany({
+      where: { userId },
+      select: {
+        id: true,
+        awardTitle: true,
+        awardImageUrl: true,
+        phase: {
+          select: {
+            certificateTitle: true,
+            certificateImageUrl: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
     }),
   ])
 
@@ -81,6 +96,20 @@ export async function loadProfilePageData(
       return db - da
     })
 
+  const certificates = certificateAwards
+    .map((a) => {
+      const imageUrl =
+        a.awardImageUrl?.trim() ||
+        a.phase.certificateImageUrl?.trim() ||
+        ''
+      const title =
+        a.awardTitle?.trim() ||
+        a.phase.certificateTitle?.trim() ||
+        'Certificado'
+      return { id: a.id, title, imageUrl }
+    })
+    .filter((c) => c.imageUrl.length > 0)
+
   return {
     currentUser: {
       ...user,
@@ -89,6 +118,7 @@ export async function loadProfilePageData(
     eventParticipants,
     championTrophies,
     tournamentTrophies,
+    certificates,
   }
 }
 

--- a/app/lib/upload.ts
+++ b/app/lib/upload.ts
@@ -71,6 +71,45 @@ export async function saveEnigmaPhaseUpload(
   return `/uploads/enigmas/${filename}`
 }
 
+const CERT_JPEG_MAX_BYTES = 12 * 1024 * 1024
+
+/**
+ * JPEG apenas, para certificado de fase de enigma.
+ * Grava em `/uploads/enigma-certificates/` com `.download-name` para o servidor enviar como anexo.
+ */
+export async function saveEnigmaCertificateJpeg(
+  file: File,
+  displayTitle: string,
+): Promise<string> {
+  if (file.size > CERT_JPEG_MAX_BYTES) {
+    throw new Error('Imagem do certificado muito grande (máximo 12 MB).')
+  }
+  const mime = (file.type || '').toLowerCase().split(';')[0].trim()
+  if (mime !== 'image/jpeg' && mime !== 'image/jpg') {
+    throw new Error('O certificado tem de ser uma imagem JPEG (.jpg ou .jpeg).')
+  }
+
+  const uploadDir = join(process.cwd(), 'uploads', 'enigma-certificates')
+  await mkdir(uploadDir, { recursive: true })
+
+  const filename = `${crypto.randomUUID()}.jpg`
+  const buffer = Buffer.from(await file.arrayBuffer())
+  await writeFile(join(uploadDir, filename), buffer)
+
+  const base =
+    displayTitle.replace(/^.*[/\\]/, '').trim().slice(0, 200) || 'certificado'
+  const downloadLabel = base.toLowerCase().endsWith('.jpg')
+    ? base
+    : `${base}.jpg`
+  await writeFile(
+    join(uploadDir, `${filename}.download-name`),
+    downloadLabel,
+    'utf8',
+  )
+
+  return `/uploads/enigma-certificates/${filename}`
+}
+
 export async function saveUploadedFile(
   file: File,
   folder: string = 'enigmas',

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -40,6 +40,9 @@ export default function Route({ loaderData }: Route.ComponentProps) {
         <div className="mb-4 flex justify-center px-4 sm:mb-6">
           <Title />
         </div>
+        <p className="font-brand text-foreground mx-auto mb-5 max-w-4xl px-4 text-center text-5xl leading-tight tracking-wide text-balance sm:mb-6 sm:text-6xl md:mb-8 md:text-7xl">
+          Seu Labirinto Lúdico
+        </p>
         <div className="px-2 sm:px-4 md:px-6">
           <Board initialSelectedTileId={loaderData.initialSelectedTileId} />
         </div>

--- a/app/routes/enigmas/route.tsx
+++ b/app/routes/enigmas/route.tsx
@@ -73,6 +73,8 @@ export async function loader({ context }: Route.LoaderArgs) {
 const ENIGMAS_WHATSAPP_GROUP_URL =
   'https://chat.whatsapp.com/Gybjbjr4RvZEqvh7HO78ec'
 
+const ENIGMAS_INTRO_YOUTUBE_EMBED_ID = 'CRXr48uHaz4'
+
 function WhatsAppGlyph({ className }: { className?: string }) {
   return (
     <svg
@@ -382,7 +384,7 @@ export default function Route({ loaderData }: Route.ComponentProps) {
       <div className="relative overflow-x-hidden">
         <EnigmasFlamingoBackdrop />
         <Center className="relative z-[1]">
-        <div className="relative mx-auto max-w-4xl px-6 py-10">
+        <div className="relative mx-auto max-w-4xl px-6 py-10 md:max-w-5xl lg:max-w-6xl">
           {/* Overlay para usuários não logados */}
           {!isLoggedIn && (
             <div
@@ -423,7 +425,24 @@ export default function Route({ loaderData }: Route.ComponentProps) {
             <p className="mt-4 text-xs font-medium uppercase tracking-[0.28em] text-foreground/55 sm:text-sm sm:tracking-[0.22em]">
               Escolha uma porta e seja bem-vindo
             </p>
+            <p className="mx-auto mt-2.5 max-w-xl text-balance px-2 text-[0.5625rem] font-medium uppercase leading-relaxed tracking-[0.2em] text-foreground/45 sm:text-[0.625rem] sm:tracking-[0.17em] md:text-[0.6875rem] md:tracking-[0.15em]">
+              Recomendamos que jogue em um computador para que tenha a melhor experiência
+            </p>
           </header>
+
+          <div className="mx-auto mb-10 w-full max-w-3xl">
+            <div className="aspect-video w-full overflow-hidden rounded-xl border border-foreground/15 bg-foreground/5 shadow-md">
+              <iframe
+                className="h-full w-full"
+                src={`https://www.youtube.com/embed/${ENIGMAS_INTRO_YOUTUBE_EMBED_ID}`}
+                title="Vídeo de apresentação — Enigmazeps"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                referrerPolicy="strict-origin-when-cross-origin"
+                allowFullScreen
+                loading="lazy"
+              />
+            </div>
+          </div>
 
           {isAdmin && (
             <div className="mb-8 flex justify-center">
@@ -449,15 +468,29 @@ export default function Route({ loaderData }: Route.ComponentProps) {
               </p>
             </div>
           ) : (
-            <div className="flex flex-col items-center gap-8">
-              {loaderData.enigmas.map((enigma) => (
-                <div key={enigma.id} className="w-full max-w-md">
-                  <EnigmaDoorCard
-                    enigma={enigma}
-                    isAdmin={isAdmin}
-                  />
-                </div>
-              ))}
+            <div className="mx-auto grid w-full max-w-md grid-cols-1 gap-8 md:max-w-none md:grid-cols-2 md:gap-x-6 md:gap-y-8 lg:gap-x-8">
+              {loaderData.enigmas.map((enigma, index) => {
+                const isLastOdd =
+                  index === loaderData.enigmas.length - 1 &&
+                  loaderData.enigmas.length % 2 === 1
+                return (
+                  <div
+                    key={enigma.id}
+                    className={
+                      isLastOdd
+                        ? 'min-w-0 md:col-span-2 md:flex md:justify-center'
+                        : 'min-w-0'
+                    }
+                  >
+                    <div className={isLastOdd ? 'w-full md:max-w-md' : 'w-full'}>
+                      <EnigmaDoorCard
+                        enigma={enigma}
+                        isAdmin={isAdmin}
+                      />
+                    </div>
+                  </div>
+                )
+              })}
             </div>
           )}
 

--- a/app/routes/enigmas_.$slug/route.tsx
+++ b/app/routes/enigmas_.$slug/route.tsx
@@ -16,6 +16,7 @@ import {
 } from '~/lib/enigma-play-public'
 import { enigmaRobotsMeta } from '~/lib/enigma-robots-meta'
 import { resolvePhaseAnswerSubmission } from '~/lib/enigma-phase-answer.server'
+import { grantEnigmaPhaseCertificateIfEligible } from '~/lib/enigma-phase-certificate-award.server'
 import { redirectWithCelebrationCookie } from '~/lib/enigma-celebration-cookie.server'
 import {
   getPlayablePhasesOrdered,
@@ -121,6 +122,12 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   if (resolution.kind === 'wrong') {
     return data({ wrong: true as const })
   }
+
+  await grantEnigmaPhaseCertificateIfEligible(
+    context.prisma,
+    context.currentUser,
+    phaseFull,
+  )
 
   const isLast = phaseFull.order === playable[playable.length - 1]!.order
   if (isLast) {

--- a/app/routes/enigmas_.$slug_.$phaseKey/route.tsx
+++ b/app/routes/enigmas_.$slug_.$phaseKey/route.tsx
@@ -27,6 +27,7 @@ import {
   hasMorePhasesAfterPlayableWindow,
 } from '~/lib/enigma-public-phases.server'
 import { Role } from '~/generated/prisma/enums'
+import { grantEnigmaPhaseCertificateIfEligible } from '~/lib/enigma-phase-certificate-award.server'
 
 export async function loader({ context, params, request }: Route.LoaderArgs) {
   const { slug, phaseKey } = params
@@ -205,6 +206,12 @@ export async function action({ request, context, params }: Route.ActionArgs) {
   if (resolution.kind === 'wrong') {
     return data({ wrong: true as const })
   }
+
+  await grantEnigmaPhaseCertificateIfEligible(
+    context.prisma,
+    context.currentUser,
+    phaseFull,
+  )
 
   const isLast = phaseFull.order === playable[playable.length - 1]!.order
   if (isLast) {

--- a/app/routes/enigmas_.$slug_.edit/route.tsx
+++ b/app/routes/enigmas_.$slug_.edit/route.tsx
@@ -130,6 +130,12 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     const entrancePasswordPromptRaw = (formData.get('entrancePasswordPrompt') as string) ?? ''
     const entrancePasswordPrompt =
       entrancePasswordPromptRaw.trim() === '' ? null : entrancePasswordPromptRaw.trim()
+    const parabensScreenBodyRaw = (formData.get('parabensScreenBody') as string) ?? ''
+    const interludeScreenBodyRaw = (formData.get('interludeScreenBody') as string) ?? ''
+    const parabensScreenBody =
+      parabensScreenBodyRaw.trim() === '' ? null : parabensScreenBodyRaw.trim()
+    const interludeScreenBody =
+      interludeScreenBodyRaw.trim() === '' ? null : interludeScreenBodyRaw.trim()
 
     const parseOptOrder = (v: FormDataEntryValue | null): number | null => {
       if (v == null || v === '') return null
@@ -182,6 +188,8 @@ export async function action({ request, context, params }: Route.ActionArgs) {
       cardSymbol: EnigmaCardSymbol
       published: boolean
       entrancePasswordPrompt: string | null
+      parabensScreenBody: string | null
+      interludeScreenBody: string | null
       publicPhaseOrderFrom: number | null
       publicPhaseOrderTo: number | null
       entrancePasswordHash?: string | null
@@ -191,6 +199,8 @@ export async function action({ request, context, params }: Route.ActionArgs) {
       cardSymbol,
       published,
       entrancePasswordPrompt,
+      parabensScreenBody,
+      interludeScreenBody,
       publicPhaseOrderFrom,
       publicPhaseOrderTo,
     }
@@ -244,22 +254,12 @@ export default function Route({ loaderData }: Route.ComponentProps) {
       <Center>
         <div className="mx-auto max-w-2xl px-6 py-10">
           {/* Header */}
-          <header className="mb-8">
-            <h1 className="font-brand text-2xl tracking-wide">
+          <header className="mb-8 text-center">
+            <h1 className="font-brand text-2xl tracking-wide text-foreground/70">
               Gerenciar enigma
             </h1>
-            <p className="mt-1 text-sm uppercase tracking-[0.2em] text-foreground/50">
+            <p className="mt-4 text-balance font-brand text-3xl font-semibold tracking-wide text-foreground/95 sm:text-4xl">
               {enigma.name}
-            </p>
-            <p className="mt-3 text-sm text-foreground/55">
-              <a
-                href="#enigma-card-symbol-fieldset"
-                className="font-medium text-primary underline decoration-primary/40 underline-offset-2 hover:decoration-primary"
-              >
-                Símbolo do cartão em /enigmas
-              </a>
-              {' — '}
-              escolhe na secção abaixo (no topo do formulário Informações).
             </p>
           </header>
 
@@ -280,15 +280,6 @@ export default function Route({ loaderData }: Route.ComponentProps) {
 
                 <EnigmaCardSymbolFormField
                   defaultSymbol={parseEnigmaCardSymbol(enigma.cardSymbol)}
-                  helperText={
-                    <>
-                      Ícone deste enigma na página{' '}
-                      <span className="font-mono text-foreground/70">/enigmas</span>.
-                      Escolhe um símbolo e confirma com{' '}
-                      <strong className="text-foreground/80">Salvar alterações</strong> no fim
-                      deste formulário.
-                    </>
-                  }
                 />
 
                 <TextInput
@@ -325,10 +316,8 @@ export default function Route({ loaderData }: Route.ComponentProps) {
                     Fases visíveis ao público
                   </h3>
                   <p className="mb-4 text-sm text-foreground/55">
-                    Com o enigma publicado, só quem não é administrador vê as fases cuja{' '}
-                    <strong className="text-foreground/75">ordem</strong> estiver entre os valores
-                    abaixo (inclusive). Deixe os dois campos vazios para liberar todas as fases. Podes
-                    ir ampliando o intervalo quando quiseres lançar mais conteúdo.
+                    Deixe os campos vazios para publicar o enigma completo. Admins podem acessar
+                    todas as fases existentes sempre.
                   </p>
                   <p className="mb-3 text-xs text-foreground/45">
                     Ordens existentes neste enigma: {orderMin}–{orderMax}
@@ -419,6 +408,41 @@ export default function Route({ loaderData }: Route.ComponentProps) {
                     className="w-full rounded-md border-1 p-2 text-sm"
                     defaultValue={enigma.entrancePasswordPrompt ?? ''}
                     placeholder="Este enigma está protegido por senha. Digite-a para continuar."
+                  />
+                </div>
+
+                <div className="rounded-xl border border-foreground/15 bg-foreground/[0.02] p-4">
+                  <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-foreground/55">
+                    Textos das telas finais
+                  </h3>
+                  <p className="mb-4 text-sm text-foreground/55">
+                    Deixe em branco para manter o texto padrão do site.
+                  </p>
+                  <label
+                    className="mb-1 block text-sm font-medium text-foreground/80"
+                    htmlFor="parabensScreenBody"
+                  >
+                    Tela Parabéns
+                  </label>
+                  <textarea
+                    id="parabensScreenBody"
+                    name="parabensScreenBody"
+                    rows={5}
+                    className="mb-5 w-full rounded-md border-1 p-2 text-sm"
+                    defaultValue={enigma.parabensScreenBody ?? ''}
+                  />
+                  <label
+                    className="mb-1 block text-sm font-medium text-foreground/80"
+                    htmlFor="interludeScreenBody"
+                  >
+                    Tela de fim do bloco público («há mais por vir»)
+                  </label>
+                  <textarea
+                    id="interludeScreenBody"
+                    name="interludeScreenBody"
+                    rows={6}
+                    className="w-full rounded-md border-1 p-2 text-sm"
+                    defaultValue={enigma.interludeScreenBody ?? ''}
                   />
                 </div>
 

--- a/app/routes/enigmas_.$slug_.edit_.phases_.$phaseId/route.tsx
+++ b/app/routes/enigmas_.$slug_.edit_.phases_.$phaseId/route.tsx
@@ -15,6 +15,7 @@ import {
   ENIGMA_PHASE_DUPLICATE_ANSWER_ERROR,
   phaseAnswerConflictsWithSiblingPhases,
 } from '~/lib/enigma-phase-answer.server'
+import { resolvePhaseCertificateFromForm } from '~/lib/enigma-phase-certificate.server'
 import { toYouTubeEmbedUrl } from '~/lib/youtube'
 import { Role } from '~/generated/prisma/enums'
 
@@ -154,6 +155,15 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     return data({ error: msg }, { status: 400 })
   }
 
+  const resolvedCert = await resolvePhaseCertificateFromForm(formData, {
+    providesCertificate: existingPhase.providesCertificate,
+    certificateTitle: existingPhase.certificateTitle,
+    certificateImageUrl: existingPhase.certificateImageUrl,
+  })
+  if (!resolvedCert.ok) {
+    return data({ error: resolvedCert.error }, { status: 400 })
+  }
+
   const phase = await context.prisma.enigmaPhase.update({
     where: { id: Number(params.phaseId) },
     data: {
@@ -173,6 +183,9 @@ export async function action({ request, context, params }: Route.ActionArgs) {
       extraTipPhrases: textExtras.extraTipPhrases,
       extraHiddenHints: textExtras.extraHiddenHints,
       whiteScreenHints,
+      providesCertificate: resolvedCert.providesCertificate,
+      certificateTitle: resolvedCert.certificateTitle,
+      certificateImageUrl: resolvedCert.certificateImageUrl,
     },
     include: { enigma: true },
   })
@@ -229,6 +242,9 @@ export default function Route({ loaderData, actionData }: Route.ComponentProps) 
                   extraTipPhrases: phase.extraTipPhrases,
                   extraHiddenHints: phase.extraHiddenHints,
                   whiteScreenHints: phase.whiteScreenHints,
+                  providesCertificate: phase.providesCertificate,
+                  certificateTitle: phase.certificateTitle,
+                  certificateImageUrl: phase.certificateImageUrl,
                 }}
                 submitLabel="Salvar alterações"
                 submitDisabled={formBusy}

--- a/app/routes/enigmas_.$slug_.edit_.phases_.new/route.tsx
+++ b/app/routes/enigmas_.$slug_.edit_.phases_.new/route.tsx
@@ -15,6 +15,7 @@ import {
   ENIGMA_PHASE_DUPLICATE_ANSWER_ERROR,
   phaseAnswerConflictsWithSiblingPhases,
 } from '~/lib/enigma-phase-answer.server'
+import { resolvePhaseCertificateFromForm } from '~/lib/enigma-phase-certificate.server'
 import { allocateUniquePlayPathToken } from '~/lib/enigma-play-path-token.server'
 import { toYouTubeEmbedUrl } from '~/lib/youtube'
 import { Role } from '~/generated/prisma/enums'
@@ -120,6 +121,15 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     return data({ error: msg }, { status: 400 })
   }
 
+  const resolvedCert = await resolvePhaseCertificateFromForm(formData, {
+    providesCertificate: false,
+    certificateTitle: null,
+    certificateImageUrl: null,
+  })
+  if (!resolvedCert.ok) {
+    return data({ error: resolvedCert.error }, { status: 400 })
+  }
+
   const playPathToken = await allocateUniquePlayPathToken(
     context.prisma,
     enigma.id,
@@ -145,6 +155,9 @@ export async function action({ request, context, params }: Route.ActionArgs) {
       extraTipPhrases: textExtras.extraTipPhrases,
       extraHiddenHints: textExtras.extraHiddenHints,
       whiteScreenHints,
+      providesCertificate: resolvedCert.providesCertificate,
+      certificateTitle: resolvedCert.certificateTitle,
+      certificateImageUrl: resolvedCert.certificateImageUrl,
     },
   })
 

--- a/app/routes/enigmas_.$slug_.entrada/route.tsx
+++ b/app/routes/enigmas_.$slug_.entrada/route.tsx
@@ -14,7 +14,11 @@ import {
   setEnigmaUnlockCookieHeader,
   userBypassesEnigmaPasswordGateLive,
 } from '~/lib/enigma-entrance-access.server'
-import { loadEnigmaLightForPlay } from '~/lib/enigma-play-queries.server'
+import { grantEnigmaPhaseCertificateIfEligible } from '~/lib/enigma-phase-certificate-award.server'
+import {
+  loadEnigmaLightForPlay,
+  loadEnigmaPhasePlayPayload,
+} from '~/lib/enigma-play-queries.server'
 import { enigmaRobotsMeta } from '~/lib/enigma-robots-meta'
 import { redirectWithCelebrationCookie } from '~/lib/enigma-celebration-cookie.server'
 import {
@@ -183,6 +187,19 @@ export async function action({ request, context, params }: Route.ActionArgs) {
     return data({
       error: 'Não encontramos essa resposta neste enigma. Confira ortografia e espaços.',
     })
+  }
+
+  const matchedPhase = playable[matchIndex]!
+  const matchedPhaseFull = await loadEnigmaPhasePlayPayload(
+    context.prisma,
+    matchedPhase.id,
+  )
+  if (matchedPhaseFull) {
+    await grantEnigmaPhaseCertificateIfEligible(
+      context.prisma,
+      context.currentUser,
+      matchedPhaseFull,
+    )
   }
 
   const isLast = matchIndex === playable.length - 1

--- a/prisma/migrations/20260416120000_enigma_phase_certificate/migration.sql
+++ b/prisma/migrations/20260416120000_enigma_phase_certificate/migration.sql
@@ -1,0 +1,21 @@
+-- Certificado por fase (config na fase; conquista por utilizador na primeira resposta certa)
+ALTER TABLE "EnigmaPhase" ADD COLUMN "providesCertificate" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "EnigmaPhase" ADD COLUMN "certificateTitle" TEXT;
+ALTER TABLE "EnigmaPhase" ADD COLUMN "certificateImageUrl" TEXT;
+
+CREATE TABLE "EnigmaPhaseCertificateAward" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" INTEGER NOT NULL,
+    "enigmaPhaseId" INTEGER NOT NULL,
+
+    CONSTRAINT "EnigmaPhaseCertificateAward_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "EnigmaPhaseCertificateAward_userId_enigmaPhaseId_key" ON "EnigmaPhaseCertificateAward"("userId", "enigmaPhaseId");
+
+CREATE INDEX "EnigmaPhaseCertificateAward_userId_idx" ON "EnigmaPhaseCertificateAward"("userId");
+
+ALTER TABLE "EnigmaPhaseCertificateAward" ADD CONSTRAINT "EnigmaPhaseCertificateAward_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "EnigmaPhaseCertificateAward" ADD CONSTRAINT "EnigmaPhaseCertificateAward_enigmaPhaseId_fkey" FOREIGN KEY ("enigmaPhaseId") REFERENCES "EnigmaPhase"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260416140000_certificate_award_snapshots/migration.sql
+++ b/prisma/migrations/20260416140000_certificate_award_snapshots/migration.sql
@@ -1,0 +1,10 @@
+-- Cópia no momento da conquista: o perfil usa estes campos (a fase pode ser editada depois).
+ALTER TABLE "EnigmaPhaseCertificateAward" ADD COLUMN "awardTitle" TEXT;
+ALTER TABLE "EnigmaPhaseCertificateAward" ADD COLUMN "awardImageUrl" TEXT;
+
+UPDATE "EnigmaPhaseCertificateAward" AS a
+SET
+  "awardTitle" = COALESCE(NULLIF(TRIM(ep."certificateTitle"), ''), 'Certificado'),
+  "awardImageUrl" = NULLIF(TRIM(ep."certificateImageUrl"), '')
+FROM "EnigmaPhase" AS ep
+WHERE ep."id" = a."enigmaPhaseId";

--- a/prisma/migrations/20260416180000_enigma_celebration_screen_texts/migration.sql
+++ b/prisma/migrations/20260416180000_enigma_celebration_screen_texts/migration.sql
@@ -1,0 +1,3 @@
+-- Textos opcionais das telas Parabéns e fim do bloco público (interlúdio).
+ALTER TABLE "Enigma" ADD COLUMN "parabensScreenBody" TEXT;
+ALTER TABLE "Enigma" ADD COLUMN "interludeScreenBody" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,7 @@ model User {
   eventParticipants EventParticipant[]
   blogPosts BlogPost[]
   passwordResetTokens PasswordResetToken[]
+  enigmaPhaseCertificateAwards EnigmaPhaseCertificateAward[]
 
   @@index([email])
 }
@@ -232,6 +233,10 @@ model Enigma {
   entrancePasswordHash   String?
   /// Texto do popup de senha (vazio no servidor = texto padrão na UI)
   entrancePasswordPrompt String? @db.Text
+  /// Corpo da tela Parabéns (várias linhas). Vazio = mensagem padrão com o nome do enigma.
+  parabensScreenBody  String? @db.Text
+  /// Corpo da tela ao fim do bloco público (URL …/mais-por-vir). Vazio = textos padrão.
+  interludeScreenBody String? @db.Text
   phases    EnigmaPhase[]
 }
 
@@ -265,9 +270,33 @@ model EnigmaPhase {
   whiteScreenHints Json @default("[]")
   /// Segmento opaco em `/enigmas/:slug/:phaseKey` para esta fase (legado ainda aceita resposta da fase anterior).
   playPathToken String
+  /// Se ativo, na primeira resposta certa (utilizador autenticado) regista-se certificado no perfil.
+  providesCertificate   Boolean @default(false)
+  /// Nome exibido no perfil / sugerido ao descarregar o JPEG.
+  certificateTitle      String?
+  /// Caminho servido em `/uploads/enigma-certificates/…` (só JPEG).
+  certificateImageUrl   String?
+
+  certificateAwards EnigmaPhaseCertificateAward[]
 
   @@unique([enigmaId, order])
   @@unique([enigmaId, playPathToken])
+}
+
+model EnigmaPhaseCertificateAward {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  userId    Int
+  user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  enigmaPhaseId Int
+  phase     EnigmaPhase @relation(fields: [enigmaPhaseId], references: [id], onDelete: Cascade)
+  /// Cópia do nome no momento da conquista (perfil não depende só da fase atual).
+  awardTitle    String?
+  /// Cópia do URL do JPEG no momento da conquista.
+  awardImageUrl String?
+
+  @@unique([userId, enigmaPhaseId])
+  @@index([userId])
 }
 
 enum MediaType {

--- a/server.js
+++ b/server.js
@@ -109,6 +109,59 @@ app.get('/uploads/enigmas/:filename', (req, res, next) => {
   })
 })
 
+/**
+ * Certificados de enigma: JPEG em disco; força download no browser (attachment).
+ */
+app.get('/uploads/enigma-certificates/:filename', (req, res, next) => {
+  const raw = req.params.filename
+  if (
+    !raw ||
+    raw.includes('..') ||
+    raw.includes('/') ||
+    raw.includes('\\') ||
+    raw.endsWith('.download-name')
+  ) {
+    return next()
+  }
+  const safe = path.basename(raw)
+  const dir = path.join(process.cwd(), 'uploads', 'enigma-certificates')
+  const absolute = path.join(dir, safe)
+  if (!absolute.startsWith(dir)) {
+    return next()
+  }
+  try {
+    if (!fs.existsSync(absolute) || !fs.statSync(absolute).isFile()) {
+      return next()
+    }
+  } catch {
+    return next()
+  }
+
+  let downloadName = safe
+  try {
+    const meta = fs.readFileSync(`${absolute}.download-name`, 'utf8').trim()
+    if (meta) {
+      downloadName = meta.slice(0, 240)
+    }
+  } catch {
+    // sem meta
+  }
+
+  const ascii = downloadName.replace(/[\x00-\x1f\x7f"]/g, '_').slice(0, 200)
+  res.setHeader(
+    'Content-Disposition',
+    `attachment; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(downloadName)}`,
+  )
+
+  const maxAgeMs =
+    process.env.NODE_ENV === 'production' ? 365 * 24 * 60 * 60 * 1000 : 0
+  res.sendFile(absolute, { maxAge: maxAgeMs, immutable: process.env.NODE_ENV === 'production' }, (err) => {
+    if (err) {
+      next(err)
+    }
+  })
+})
+
 app.use(
   '/uploads',
   express.static('uploads', {


### PR DESCRIPTION
…ogada

- Certificados por fase (Prisma, uploads, perfil, concessão em /slug e /slug/token).

- Textos editáveis para Parabéns e tela mais-por-vim; copy do interlúdio.

- Concessão de certificado também no fluxo Continuar da entrada do enigma.

- Listagem /enigmas: duas colunas no desktop, último cartão ímpar centrado, vídeo YouTube, aviso de desktop.

- Calendário: removido evento 24/04; ajustes na edição de enigma e campo símbolo opcional.

Migrações: certificado, snapshots do prémio, textos de celebração no Enigma.

Made-with: Cursor