### PR TITLE
feat(home): slogan com Albert Sans abaixo do logo

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -35,6 +35,9 @@
   --color-on-error: var(--color-on-error);
 
   --font-brand: 'Farmshow';
+  --font-albert-sans:
+    'Albert Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --font-default:
     'Inter', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -22,6 +22,10 @@ export const links: Route.LinksFunction = () => [
     rel: 'stylesheet',
     href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap',
   },
+  {
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css2?family=Albert+Sans:ital,wght@0,100..900;1,100..900&display=swap',
+  },
 ]
 
 export const meta = ({}: Route.MetaArgs) => {

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -37,12 +37,12 @@ export default function Route({ loaderData }: Route.ComponentProps) {
     <>
       <div className="relative w-full sm:pb-20">
         <HomeThemeHint />
-        <div className="mb-4 flex justify-center px-4 sm:mb-6">
+        <div className="mb-5 flex flex-col items-center px-4 sm:mb-6 md:mb-8">
           <Title />
+          <p className="font-albert-sans text-foreground mt-8 max-w-4xl text-center text-sm leading-snug text-balance font-normal tracking-normal sm:mt-10 sm:text-base md:mt-12 md:text-lg">
+            Seu Labirinto Lúdico
+          </p>
         </div>
-        <p className="font-brand text-foreground mx-auto mb-5 max-w-4xl px-4 text-center text-5xl leading-tight tracking-wide text-balance sm:mb-6 sm:text-6xl md:mb-8 md:text-7xl">
-          Seu Labirinto Lúdico
-        </p>
         <div className="px-2 sm:px-4 md:px-6">
           <Board initialSelectedTileId={loaderData.initialSelectedTileId} />
         </div>


### PR DESCRIPTION
- Agrupa título e frase Seu Labirinto Lúdico em coluna, com margem para não sobrepor as placas do tema.

- Tipografia Albert Sans (Google Fonts) e tamanho menor; capitalização natural da frase.

- Registra --font-albert-sans no tema Tailwind.

Made-with: Cursor