### PR TITLE
fix(nav): menu mobile acima do conteúdo; CI checkout Node 24

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -10,8 +10,11 @@ jobs:
     name: Deploy app
     runs-on: ubuntu-latest
     concurrency: deploy-group # optional: ensure only one action runs at a time
+    env:
+      # Node 20 nas JavaScript actions está deprecated; GitHub migra o default para Node 24.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
         env:

--- a/app/components/menu-navigation/menu-navigation.component.tsx
+++ b/app/components/menu-navigation/menu-navigation.component.tsx
@@ -70,7 +70,7 @@ export default function MenuNavigation({ children, className }: MenuNavigationPr
               opacity: 0,
               filter: 'blur(8px)',
             }}
-            className="border-on-secondary bg-background text-on-background absolute top-4 right-4 left-auto flex flex-col rounded-md border py-2 z-1"
+            className="border-on-secondary bg-background text-on-background absolute top-4 right-4 left-auto z-[100] flex max-h-[min(70vh,calc(100dvh-5rem))] flex-col overflow-y-auto rounded-md border py-2 shadow-xl"
           >
             <Button
               styleType="invisible"

--- a/app/routes/_base-layout.tsx
+++ b/app/routes/_base-layout.tsx
@@ -25,7 +25,7 @@ export default function Route({ loaderData, matches }: Route.ComponentProps) {
     <>
       <nav
         id="main-nav"
-        className="relative flex items-center justify-end gap-4 p-4"
+        className="relative z-50 flex items-center justify-end gap-4 p-4"
       >
         <BackButtonPortalContainer />
         {!isInHome && (


### PR DESCRIPTION
- nav z-50 e painel MenuNavigation z-[100] para o dropdown ficar à frente dos cards (ex.: /enigmas).

- fly-deploy: actions/checkout@v6 e FORCE_JAVASCRIPT_ACTIONS_TO_NODE24.

Made-with: Cursor