### PR TITLE
fix(enigma): omit celebration screen bodies from phase route loader data

### DIFF
--- a/app/lib/enigma-play-public.ts
+++ b/app/lib/enigma-play-public.ts
@@ -49,17 +49,34 @@ export function toPublicEnigmaPhase<
   }
 }
 
+/**
+ * Conteúdo de celebração não entra no HTML das fases de jogo (vaza no `loaderData` serializado).
+ * Em `/parabens` e `/mais-por-vir` podes passar o modo correspondente; evita o outro corpo nessa rota.
+ */
+export type PublicEnigmaCelebrationBodies =
+  | 'none'
+  | 'parabensOnly'
+  | 'interludeOnly'
+  | 'both'
+
 /** Só o necessário para a tela de jogar / parabéns (evita vazar `phases[].answer`). */
-export function toPublicEnigmaPlay(enigma: {
-  name: string
-  parabensScreenBody?: string | null
-  interludeScreenBody?: string | null
-}) {
+export function toPublicEnigmaPlay(
+  enigma: {
+    name: string
+    parabensScreenBody?: string | null
+    interludeScreenBody?: string | null
+  },
+  celebrationBodies: PublicEnigmaCelebrationBodies = 'both',
+) {
   const parabens = enigma.parabensScreenBody?.trim()
   const interlude = enigma.interludeScreenBody?.trim()
+  const wantParabens =
+    celebrationBodies === 'both' || celebrationBodies === 'parabensOnly'
+  const wantInterlude =
+    celebrationBodies === 'both' || celebrationBodies === 'interludeOnly'
   return {
     name: enigma.name,
-    parabensScreenBody: parabens ? parabens : null,
-    interludeScreenBody: interlude ? interlude : null,
+    parabensScreenBody: wantParabens && parabens ? parabens : null,
+    interludeScreenBody: wantInterlude && interlude ? interlude : null,
   }
 }

--- a/app/routes/enigmas_.$slug/route.tsx
+++ b/app/routes/enigmas_.$slug/route.tsx
@@ -58,7 +58,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
   if (!phaseFull) throw new Response('Not Found', { status: 404 })
 
   return {
-    enigma: toPublicEnigmaPlay(enigma),
+    enigma: toPublicEnigmaPlay(enigma, 'none'),
     phase: toPublicEnigmaPhase(phaseFull),
     isFinished: false,
     isAdmin: context.currentUser?.role === Role.ADMIN,

--- a/app/routes/enigmas_.$slug_.$phaseKey/route.tsx
+++ b/app/routes/enigmas_.$slug_.$phaseKey/route.tsx
@@ -65,7 +65,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     )
     if (!ok) return redirect(`/enigmas/${slug}`)
     return {
-      enigma: toPublicEnigmaPlay(enigma),
+      enigma: toPublicEnigmaPlay(enigma, 'parabensOnly'),
       phase: null,
       isFinished: true,
       celebrationKind: 'full' as const,
@@ -91,7 +91,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
     )
     if (!ok) return redirect(`/enigmas/${slug}`)
     return {
-      enigma: toPublicEnigmaPlay(enigma),
+      enigma: toPublicEnigmaPlay(enigma, 'interludeOnly'),
       phase: null,
       isFinished: true,
       celebrationKind: 'interlude' as const,
@@ -118,7 +118,7 @@ export async function loader({ context, params, request }: Route.LoaderArgs) {
   if (!phaseFull) throw new Response('Not Found', { status: 404 })
 
   return {
-    enigma: toPublicEnigmaPlay(enigma),
+    enigma: toPublicEnigmaPlay(enigma, 'none'),
     phase: toPublicEnigmaPhase(phaseFull),
     isFinished: false,
     isAdmin: context.currentUser?.role === Role.ADMIN,


### PR DESCRIPTION
Stops interludeScreenBody and parabensScreenBody from being serialized in the React Router context on play pages, so the text does not appear in view-source. Bodies are sent only on /parabens and /mais-por-vir.

Made-with: Cursor